### PR TITLE
Added custom .srs support

### DIFF
--- a/podkop/files/etc/init.d/podkop
+++ b/podkop/files/etc/init.d/podkop
@@ -744,23 +744,24 @@ sing_box_dns_rule_fakeip() {
 }
 
 sing_box_dns_rule_fakeip_section() {
-    local rule_set=$1
-    echo $rule_set
-    log "Adding section to fakeip route rules in sing-box"
-
+    local rule_set_tag="$1"
+    
+    log "Adding rule_set '$rule_set_tag' to fakeip-server configuration"
+    
     jq \
-    --arg rule_set "$rule_set" \
-    '.dns.rules |= map(
-        if .server == "fakeip-server" then 
-            if any(.rule_set[]?; . == $rule_set) then 
+    --arg rule_set_tag "$rule_set_tag" \
+    '
+    .dns.rules |= map(
+        if .server == "fakeip-server" then
+            if (.rule_set | index($rule_set_tag)) == null then
+                .rule_set += [$rule_set_tag]
+            else
                 .
-            else 
-                .rule_set += [$rule_set] 
             end
-        else 
-            . 
+        else
+            .
         end
-    )' "$SING_BOX_CONFIG" >/tmp/sing-box-config-tmp.json && mv /tmp/sing-box-config-tmp.json "$SING_BOX_CONFIG"
+    )' "$SING_BOX_CONFIG" > /tmp/sing-box-config-tmp.json && mv /tmp/sing-box-config-tmp.json "$SING_BOX_CONFIG"
 }
 
 sing_box_cache_file() {
@@ -1227,34 +1228,52 @@ process_domains_for_section() {
 sing_box_ruleset_remote() {
     local tag=$1
     local type=$2
-    local update_interval=$3
+    local url=$3
+    local update_interval=${4:-"1d"}
+    
+    if ! echo "$url" | grep -qE '^https?://'; then
+        log "Invalid URL format: $url"
+        return 1
+    fi
 
-    url="$SRS_MAIN_URL/$tag.srs"
-
-    local tag_exists=$(jq -r --arg tag "$tag" '
+    local exists=$(jq -r --arg tag "$tag" '
         .route.rule_set[]? | select(.tag == $tag) | .tag
     ' "$SING_BOX_CONFIG")
-
-    if [[ -n "$tag_exists" ]]; then
-        log "Ruleset with tag $tag already exists. Skipping addition."
+    
+    if [ -n "$exists" ]; then
+        log "Updating existing SRS: $tag"
+        jq \
+        --arg tag "$tag" \
+        --arg url "$url" \
+        '
+        .route.rule_set |= map(
+            if .tag == $tag then 
+                .url = $url 
+            else . 
+            end
+        )' "$SING_BOX_CONFIG" > /tmp/sing-box-config-tmp.json
     else
+        log "Adding new SRS: $tag"
         jq \
         --arg tag "$tag" \
         --arg type "$type" \
         --arg url "$url" \
-        --arg update_interval "$update_interval" \
+        --arg interval "$update_interval" \
         '
-        .route.rule_set += [
-            {
-                "tag": $tag,
-                "type": $type,
-                "format": "binary",
-                "url": $url,
-                "update_interval": $update_interval
-            }
-        ]' "$SING_BOX_CONFIG" > /tmp/sing-box-config-tmp.json && mv /tmp/sing-box-config-tmp.json "$SING_BOX_CONFIG"
+        .route.rule_set += [{
+            "tag": $tag,
+            "type": $type,
+            "format": "binary",
+            "url": $url,
+            "update_interval": $interval
+        }]' "$SING_BOX_CONFIG" > /tmp/sing-box-config-tmp.json
+    fi
 
-        log "Added new ruleset with tag $tag"
+    if mv /tmp/sing-box-config-tmp.json "$SING_BOX_CONFIG"; then
+        log "SRS '$tag' configured: $url"
+    else
+        log "Critical error: Failed to update config!"
+        return 1
     fi
 }
 
@@ -1295,31 +1314,42 @@ list_subnets_download() {
 }
 
 sing_box_rules() {
-    log "Configure rule in sing-box"
-    local rule_set="$1"
-    local outbound="$2"
+    local rule_set_tag="$1"
+    
+    log "Updating route rules with tag: $rule_set_tag"
 
-    # Check if there is an outbound rule for "tproxy-in"
-    local rule_exists=$(jq -r '.route.rules[] | select(.outbound == "'"$outbound"'" and .inbound == ["tproxy-in"])' "$SING_BOX_CONFIG")
-
-    if [[ -n "$rule_exists" ]]; then
-        # If a rule for tproxy-in exists, add a new rule_set to the existing rule
+    local rule_index=$(jq -r '
+        .route.rules | 
+        to_entries[] | 
+        select(.value.inbound == ["tproxy-in"]) | 
+        .key
+    ' "$SING_BOX_CONFIG")
+    
+    if [ -n "$rule_index" ]; then
         jq \
-        --arg rule_set "$rule_set" \
-        --arg outbound "$outbound" \
-        '(.route.rules[] | select(.outbound == $outbound and .inbound == ["tproxy-in"]) .rule_set) += [$rule_set]' \
-        "$SING_BOX_CONFIG" >/tmp/sing-box-config-tmp.json && mv /tmp/sing-box-config-tmp.json "$SING_BOX_CONFIG"
+        --argjson idx "$rule_index" \
+        --arg tag "$rule_set_tag" \
+        '
+        .route.rules[$idx].rule_set |= 
+            if index($tag) then . else . + [$tag] end
+        ' "$SING_BOX_CONFIG" > /tmp/sing-box-config-tmp.json
+        
+        if mv /tmp/sing-box-config-tmp.json "$SING_BOX_CONFIG"; then
+            log "Route rules updated successfully"
+        else
+            log "Error updating route rules"
+        fi
     else
-        # If there is no rule for tproxy-in, create a new one with rule_set
+        log "Creating new route rule for tag: $rule_set_tag"
         jq \
-        --arg rule_set "$rule_set" \
-        --arg outbound "$outbound" \
-        '.route.rules += [{
+        --arg tag "$rule_set_tag" \
+        '
+        .route.rules += [{
             "inbound": ["tproxy-in"],
-            "rule_set": [$rule_set],
-            "outbound": $outbound,
+            "rule_set": [$tag],
+            "outbound": "main",
             "action": "route"
-        }]' "$SING_BOX_CONFIG" >/tmp/sing-box-config-tmp.json && mv /tmp/sing-box-config-tmp.json "$SING_BOX_CONFIG"
+        }]' "$SING_BOX_CONFIG" > /tmp/sing-box-config-tmp.json && mv /tmp/sing-box-config-tmp.json "$SING_BOX_CONFIG"
     fi
 }
 
@@ -1343,12 +1373,18 @@ sing_box_quic_reject() {
 }
 
 process_remote_ruleset() {
+    local section="$1"
     config_get_bool domain_list_enabled "$section" "domain_list_enabled" "0"
     if [ "$domain_list_enabled" -eq 1 ]; then
-        log "Adding a srs list for $section"
-        config_list_foreach "$section" domain_list "sing_box_ruleset_remote" "remote" "1d"
-        config_list_foreach "$section" domain_list "list_subnets_download" "$section" "$domain_list"
+        log "Adding remote SRS rulesets for section $section"
+        config_list_foreach "$section" domain_list process_remote_ruleset_item
     fi
+}
+
+process_remote_ruleset_item() {
+    local tag="$1"
+    local url="${SRS_MAIN_URL}/${tag}.srs"
+    sing_box_ruleset_remote "$tag" "remote" "$url" "$interval"
 }
 
 sing_box_rule_preset() {
@@ -1398,24 +1434,46 @@ process_domains_list_local() {
 }
 
 list_custom_url_domains_create() {
-    local section="$2"
     local URL="$1"
+    local section="$2"
     local filename=$(basename "$URL")
+    local extension="${filename##*.}"
+    
+    if [ "$extension" = "srs" ]; then
+        local tag="${filename%.*}"
 
-    wget -q -O "/tmp/podkop/${filename}" "$URL"
+        if ! wget -q -O "/tmp/podkop/$filename" "$URL"; then
+            log "Failed to download SRS file: $URL"
+            return 1
+        fi
+        
+        sing_box_ruleset_remote "$tag" "remote" "$URL" "$interval" || return 1
 
-    while IFS= read -r domain; do
-        log "From local file: $domain"
-        sing_box_ruleset_domains $domain $section
-    done <"/tmp/podkop/$filename"
+        sing_box_dns_rule_fakeip_section "$tag" || return 1
+
+        sing_box_rules "$tag" || return 1
+        
+        log "SRS '$tag' fully integrated"
+
+    else
+        wget -q -O "/tmp/podkop/${filename}" "$URL" || {
+            log "Failed to download domain list: $URL"
+            return 1
+        }
+        
+        while IFS= read -r domain; do
+            domain=$(echo "$domain" | xargs)
+            [ -n "$domain" ] && sing_box_ruleset_domains "$domain" "$section"
+        done < "/tmp/podkop/$filename"
+    fi
 }
 
 process_domains_list_url() {
     local section="$1"
-
     config_get custom_download_domains_list_enabled "$section" "custom_download_domains_list_enabled"
+    
     if [ "$custom_download_domains_list_enabled" -eq 1 ]; then
-        log "Adding a custom domains list from URL in $section"
+        log "Processing custom domains/subnets lists for section $section"
         config_list_foreach "$section" "custom_download_domains" list_custom_url_domains_create "$section"
     fi
 }

--- a/podkop/files/etc/init.d/podkop
+++ b/podkop/files/etc/init.d/podkop
@@ -1388,23 +1388,59 @@ process_remote_ruleset_item() {
 }
 
 sing_box_rule_preset() {
-    config_get custom_domains_list_type "$section" "custom_domains_list_type"
-    config_get custom_subnets_list_enabled "$section" "custom_subnets_list_enabled"
-    config_get custom_local_domains_list_enabled "$section" "custom_local_domains_list_enabled"
-    config_get custom_download_domains_list_enabled "$section" "custom_download_domains_list_enabled"
+    local section="$1"
 
-    if [ "$custom_domains_list_type" != "disabled" ] || [ "$custom_subnets_list_enabled" != "disabled" ] ||
-        [ "$custom_local_domains_list_enabled" = "1" ] || [ "$custom_download_domains_list_enabled" = "1" ]; then
-        sing_box_rules "$section" "$section"
-        sing_box_dns_rule_fakeip_section "$section" "$section"
-    fi
+    config_get custom_domains_list_type "$section" "custom_domains_list_type" "disabled"
+    config_get custom_subnets_list_enabled "$section" "custom_subnets_list_enabled" "disabled"
+    config_get custom_local_domains_list_enabled "$section" "custom_local_domains_list_enabled" "0"
 
-    config_get domain_list_enabled "$section" "domain_list_enabled"
-    config_get domain_list "$section" "domain_list"
-    if [ "$domain_list_enabled" -eq 1 ]; then
-        config_list_foreach $section domain_list sing_box_rules $section
-        config_list_foreach $section domain_list sing_box_dns_rule_fakeip_section domain_list
-    fi 
+    log "[DEBUG] Проверка условий для ruleset 'main':"
+    log "  - custom_domains_list_type: $custom_domains_list_type"
+    log "  - custom_subnets_list_enabled: $custom_subnets_list_enabled"
+    log "  - custom_local_domains_list_enabled: $custom_local_domains_list_enabled"
+
+    if [ "$custom_domains_list_type" = "disabled" ] && 
+       [ "$custom_subnets_list_enabled" = "disabled" ] && 
+       [ "$custom_local_domains_list_enabled" -eq 0 ]; then
+        
+        log "Удаление ruleset 'main' (все опции отключены)..."
+
+        jq 'del(.route.rule_set[]? | select(.tag == "main"))' "$SING_BOX_CONFIG" > /tmp/sing-box-tmp.json
+
+        jq '
+            .route.rules |= map(
+                if .rule_set? then 
+                    .rule_set |= (map(select(. != "main"))) 
+                else . end
+            )
+        ' /tmp/sing-box-tmp.json > "$SING_BOX_CONFIG"
+
+        jq '
+            .route.rules |= map(
+                if .rule_set? and (.rule_set | length == 0) then 
+                    del(.rule_set) 
+                else . end
+            )
+        ' "$SING_BOX_CONFIG" > /tmp/sing-box-tmp.json && mv /tmp/sing-box-tmp.json "$SING_BOX_CONFIG"
+
+        log "Конфиг после удаления 'main':"
+        log "$(jq '.route' "$SING_BOX_CONFIG")"
+
+    else
+        log "Правила 'main' не удалены (есть активные опции)."
+
+        sing_box_rules "$section"
+        sing_box_dns_rule_fakeip_section "$section"
+    fi
+
+    config_get domain_list_enabled "$section" "domain_list_enabled"
+    if [ "$domain_list_enabled" -eq 1 ]; then
+        log "Обработка domain_list для секции $section..."
+        config_list_foreach "$section" domain_list sing_box_rules "$section"
+        config_list_foreach "$section" domain_list sing_box_dns_rule_fakeip_section
+    fi
+
+    rm -f /tmp/sing-box-tmp.json
 }
 
 list_custom_local_domains_create() {


### PR DESCRIPTION
Добавлена поддержка кастомных .srs файлов. Реализовано через функции list_custom_url_domains_create, sing_box_ruleset_remote, process_domains_list_url, process_remote_ruleset, sing_box_dns_rule_fakeip_section и sing_box_rules. Работает примерно так: пользователь в luci добавляет домен, на конце которого .srs, происходит grep, потом это отправляется в sing_box_ruleset_remote и меняется конфиг sing-box. Домены без .srs обрабатываются как обычно.