### PR TITLE
fix(podkop): prevent double opkg install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -160,13 +160,13 @@ add_tunnel() {
             ;;
 
         3)
-            opkg install opkg install openvpn-openssl luci-app-openvpn
+            opkg install openvpn-openssl luci-app-openvpn
             printf "\e[1;32mUse these instructions to configure https://itdog.info/nastrojka-klienta-openvpn-na-openwrt/\e[0m\n"
             break
             ;;
 
         4)
-            opkg install opkg install openconnect luci-proto-openconnect
+            opkg install openconnect luci-proto-openconnect
             printf "\e[1;32mUse these instructions to configure https://itdog.info/nastrojka-klienta-openconnect-na-openwrt/\e[0m\n"
             break
             ;;

--- a/luci-app-podkop/Makefile
+++ b/luci-app-podkop/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-podkop
-PKG_VERSION:=0.3.35
+PKG_VERSION:=0.3.36
 PKG_RELEASE:=1
 
 LUCI_TITLE:=LuCI podkop app

--- a/podkop/Makefile
+++ b/podkop/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=podkop
-PKG_VERSION:=0.3.35
+PKG_VERSION:=0.3.36
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=ITDog <podkop@itdog.info>


### PR DESCRIPTION
fixes an issue where opkg install commands were executed twice, leading to "unknown package" errors in some OpenWRT environments