### PR TITLE
Добавить поддержку uci commit для ubus.

### DIFF
--- a/luci-app-podkop/root/usr/share/rpcd/acl.d/luci-app-podkop.json
+++ b/luci-app-podkop/root/usr/share/rpcd/acl.d/luci-app-podkop.json
@@ -22,7 +22,12 @@
     "write": {
       "uci": [
         "podkop"
-      ]
+      ],
+      "ubus": {
+        "uci": [
+          "commit"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
Добавить поддержку ubus uci commit.

Я разрабатываю мобильное приложение с поддержкой подкопа. Приложение работает через ubus. Сейчас можно сделать все uci get/ uci set, но нельзя сделать uci commit для сохранения изменений.