### PR TITLE
feat: Add URLTest proxy configuration type with dynamic list support

### DIFF
--- a/luci-app-podkop/htdocs/luci-static/resources/view/podkop/configSection.js
+++ b/luci-app-podkop/htdocs/luci-static/resources/view/podkop/configSection.js
@@ -32,6 +32,7 @@ function createConfigSection(section, map, network) {
     o = s.taboption('basic', form.ListValue, 'proxy_config_type', _('Configuration Type'), _('Select how to configure the proxy'));
     o.value('url', _('Connection URL'));
     o.value('outbound', _('Outbound Config'));
+    o.value('urltest', _('URLTest'));
     o.default = 'url';
     o.depends('mode', 'proxy');
     o.ucisection = s.section;
@@ -204,6 +205,11 @@ function createConfigSection(section, map, network) {
             return _('Invalid JSON format');
         }
     };
+
+    o = s.taboption('basic', form.DynamicList, 'urltest_proxy_links', _('URLTest Proxy Links'));
+    o.depends('proxy_config_type', 'urltest');
+    o.placeholder = 'vless:// or ss// link';
+    o.rmempty = false;
 
     o = s.taboption('basic', form.Flag, 'ss_uot', _('Shadowsocks UDP over TCP'), _('Apply for SS2022'));
     o.default = '0';

--- a/podkop/files/usr/bin/podkop
+++ b/podkop/files/usr/bin/podkop
@@ -83,13 +83,14 @@ start_main() {
 }
 
 start() {
-    local proxy_string interface outbound_json dont_touch_dhcp
+    local proxy_string interface outbound_json urltest_proxy_links dont_touch_dhcp
     config_get proxy_string "main" "proxy_string"
     config_get interface "main" "interface"
     config_get outbound_json "main" "outbound_json"
+    config_get urltest_proxy_links "main" "urltest_proxy_links"
 
-    if [ -z "$proxy_string" ] && [ -z "$interface" ] && [ -z "$outbound_json" ]; then
-        log "Podkop start aborted: required options (proxy_string, interface, outbound_json) are missing in 'main' section"
+    if [ -z "$proxy_string" ] && [ -z "$interface" ] && [ -z "$outbound_json" ] && [ -z "$urltest_proxy_links" ]; then
+        log "Required options (proxy_string, interface, outbound_json, urltest_proxy_links) are missing in 'main' section. Aborted." "fatal"
         exit 1
     fi
 
@@ -629,7 +630,7 @@ configure_outbound_handler() {
 
         case "$proxy_config_type" in
         url)
-            log "Detected proxy configuration type: url"
+            log "Detected proxy configuration type: url" "debug"
             local proxy_string udp_over_tcp
             config_get proxy_string "$section" "proxy_string"
             config_get udp_over_tcp "$section" "ss_uot"
@@ -643,10 +644,41 @@ configure_outbound_handler() {
             config=$(sing_box_cf_add_proxy_outbound "$config" "$section" "$active_proxy_string" "$udp_over_tcp")
             ;;
         outbound)
-            log "Detected proxy configuration type: outbound"
+            log "Detected proxy configuration type: outbound" "debug"
             local json_outbound
             config_get json_outbound "$section" "outbound_json"
             config=$(sing_box_cf_add_json_outbound "$config" "$section" "$json_outbound")
+            ;;
+        urltest)
+            log "Detected proxy configuration type: urltest" "debug"
+            local urltest_proxy_links udp_over_tcp i urltest_tag selector_tag outbound_tag outbound_tags \
+                urltest_outbounds selector_outbounds
+            config_get urltest_proxy_links "$section" "urltest_proxy_links"
+            config_get udp_over_tcp "$section" "ss_uot"
+
+            if [ -z "$urltest_proxy_links" ]; then
+                log "URLTest proxy links is not set. Aborted." "fatal"
+                exit 1
+            fi
+
+            i=1
+            for link in $urltest_proxy_links; do
+                config="$(sing_box_cf_add_proxy_outbound "$config" "$section-$i" "$link" "$udp_over_tcp")"
+                outbound_tag="$(get_outbound_tag_by_section "$section-$i")"
+                if [ -z "$outbound_tags" ]; then
+                    outbound_tags="$outbound_tag"
+                else
+                    outbound_tags="$outbound_tags,$outbound_tag"
+                fi
+                i=$((i+1))
+            done
+
+            urltest_tag="$(get_outbound_tag_by_section "$section-urltest")"
+            selector_tag="$(get_outbound_tag_by_section "$section")"
+            urltest_outbounds="$(comma_string_to_json_array "$outbound_tags")"
+            selector_outbounds="$(comma_string_to_json_array "$outbound_tags,$urltest_tag")"
+            config="$(sing_box_cm_add_urltest_outbound "$config" "$urltest_tag" "$urltest_outbounds")"
+            config="$(sing_box_cm_add_selector_outbound "$config" "$selector_tag" "$selector_outbounds" "$urltest_tag")"
             ;;
         *)
             log "Unknown proxy configuration type: '$proxy_config_type'. Aborted." "fatal"

--- a/podkop/files/usr/lib/sing_box_config_manager.sh
+++ b/podkop/files/usr/lib/sing_box_config_manager.sh
@@ -833,6 +833,90 @@ sing_box_cm_add_raw_outbound() {
 }
 
 #######################################
+# Add a URLTest outbound to the outbounds section of a sing-box JSON configuration.
+# Arguments:
+#   config: JSON configuration
+#   tag: string, identifier for the URLTest outbound
+#   outbounds: JSON array of outbound tags to test
+#   url: URL to probe (optional)
+#   interval: test interval (e.g., "10s") (optional)
+#   tolerance: max latency difference tolerated (optional)
+#   idle_timeout: idle timeout duration (optional)
+#   interrupt_exist_connections: flag to interrupt existing connections ("true"/"false") (optional)
+# Outputs:
+#   Writes updated JSON configuration to stdout
+# Example:
+#   CONFIG=$(sing_box_cm_add_urltest_outbound "$CONFIG" "auto-select" '["proxy1","proxy2"]')
+#######################################
+sing_box_cm_add_urltest_outbound() {
+    local config="$1"
+    local tag="$2"
+    local outbounds="$3"
+    local url="$4"
+    local interval="$5"
+    local tolerance="$6"
+    local idle_timeout="$7"
+    local interrupt_exist_connections="$8"
+
+    echo "$config" | jq \
+        --arg tag "$tag" \
+        --argjson outbounds "$outbounds" \
+        --arg url "$url" \
+        --arg interval "$interval" \
+        --arg tolerance "$tolerance" \
+        --arg idle_timeout "$idle_timeout" \
+        --arg interrupt_exist_connections "$interrupt_exist_connections" \
+        '.outbounds += [
+            {
+                type: "urltest",
+                tag: $tag,
+                outbounds: $outbounds
+            }
+            + (if $url != "" then {url: $url} else {} end)
+            + (if $interval != "" then {interval: $interval} else {} end)
+            + (if $tolerance != "" then {tolerance: ($tolerance | tonumber)} else {} end)
+            + (if $idle_timeout != "" then {idle_timeout: $idle_timeout} else {} end)
+            + (if $interrupt_exist_connections == "true" then {interrupt_exist_connections: $interrupt_exist_connections} else {} end)
+        ]'
+}
+
+#######################################
+# Add a Selector outbound to the outbounds section of a sing-box JSON configuration.
+# Arguments:
+#   config: JSON configuration
+#   tag: string, identifier for the Selector outbound
+#   outbounds: JSON array of outbound tags to choose from
+#   default: default outbound tag if none selected (optional)
+#   interrupt_exist_connections: flag to interrupt existing connections ("true"/"false") (optional)
+# Outputs:
+#   Writes updated JSON configuration to stdout
+# Example:
+#   CONFIG=$(sing_box_cm_add_selector_outbound "$CONFIG" "select-proxy" '["proxy1","proxy2"]')
+#######################################
+sing_box_cm_add_selector_outbound() {
+    local config="$1"
+    local tag="$2"
+    local outbounds="$3"
+    local default="$4"
+    local interrupt_exist_connections="$5"
+
+    echo "$config" | jq \
+        --arg tag "$tag" \
+        --argjson outbounds "$outbounds" \
+        --arg default "$default" \
+        --arg interrupt_exist_connections "$interrupt_exist_connections" \
+        '.outbounds += [
+            {
+                type: "selector",
+                tag: $tag,
+                outbounds: $outbounds,
+                default: $default
+            }
+            + (if $interrupt_exist_connections == "true" then {interrupt_exist_connections: $interrupt_exist_connections} else {} end)
+        ]'
+}
+
+#######################################
 # Configure the route section of a sing-box JSON configuration.
 # Arguments:
 #   config: JSON configuration (string)


### PR DESCRIPTION
# Описание изменений

Добавлена поддержка URLTest в типах конфигурации прокси

## Что изменено

Детальное описание изменений:
<img width="885" height="358" alt="image" src="https://github.com/user-attachments/assets/69c023c5-9d51-49f5-8302-d83a4407f768" />
Логика работы:
- Из N ссылок строится N аутбаундов
- Создается URLTest с этими N аутбаундами
- Создается Selector с N аутбаундами и URLTest, который является выходным аутбаундом для правил