### PR TITLE
Replacing Split DNS with Domain Resolver and Bootstrap DNS

### DIFF
--- a/luci-app-podkop/htdocs/luci-static/resources/view/podkop/additionalTab.js
+++ b/luci-app-podkop/htdocs/luci-static/resources/view/podkop/additionalTab.js
@@ -60,27 +60,17 @@ function createAdditionalSection(mainSection, network) {
         return true;
     };
 
-    o = mainSection.taboption('additional', form.Flag, 'split_dns_enabled', _('Split DNS'), _('DNS for the list via proxy'));
-    o.default = '1';
+    o = mainSection.taboption('additional', form.Value, 'bootstrap_dns_server', _('Bootstrap DNS server'), _('The DNS server used to look up the IP address of an upstream DNS server'));
+    o.value('77.88.8.8', '77.88.8.8 (Yandex DNS)');
+    o.value('77.88.8.1', '77.88.8.1 (Yandex DNS)');
+    o.value('1.1.1.1', '1.1.1.1 (Cloudflare DNS)');
+    o.value('1.0.0.1', '1.0.0.1 (Cloudflare DNS)');
+    o.value('8.8.8.8', '8.8.8.8 (Google DNS)');
+    o.value('8.8.4.4', '8.8.4.4 (Google DNS)');
+    o.value('9.9.9.9', '9.9.9.9 (Quad9 DNS)');
+    o.value('9.9.9.11', '9.9.9.11 (Quad9 DNS)');
+    o.default = '77.88.8.8';
     o.rmempty = false;
-    o.ucisection = 'main';
-
-    o = mainSection.taboption('additional', form.ListValue, 'split_dns_type', _('Split DNS Protocol Type'), _('Select DNS protocol for split'));
-    o.value('doh', _('DNS over HTTPS (DoH)'));
-    o.value('dot', _('DNS over TLS (DoT)'));
-    o.value('udp', _('UDP (Unprotected DNS)'));
-    o.default = 'udp';
-    o.rmempty = false;
-    o.depends('split_dns_enabled', '1');
-    o.ucisection = 'main';
-
-    o = mainSection.taboption('additional', form.Value, 'split_dns_server', _('Split DNS Server'), _('Select or enter DNS server address'));
-    Object.entries(constants.DNS_SERVER_OPTIONS).forEach(([key, label]) => {
-        o.value(key, _(label));
-    });
-    o.default = '1.1.1.1';
-    o.rmempty = false;
-    o.depends('split_dns_enabled', '1');
     o.ucisection = 'main';
     o.validate = function (section_id, value) {
         if (!value) {
@@ -88,10 +78,9 @@ function createAdditionalSection(mainSection, network) {
         }
 
         const ipRegex = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}(:[0-9]{1,5})?$/;
-        const domainRegex = /^(?:https:\/\/)?([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-zA-Z]{2,63}(:[0-9]{1,5})?(\/[^?#\s]*)?$/;
 
-        if (!ipRegex.test(value) && !domainRegex.test(value)) {
-            return _('Invalid DNS server format. Examples: 8.8.8.8 or dns.example.com or dns.example.com/nicedns for DoH');
+        if (!ipRegex.test(value)) {
+            return _('Invalid DNS server format. Example: 8.8.8.8');
         }
 
         return true;

--- a/luci-app-podkop/htdocs/luci-static/resources/view/podkop/additionalTab.js
+++ b/luci-app-podkop/htdocs/luci-static/resources/view/podkop/additionalTab.js
@@ -196,7 +196,6 @@ function createAdditionalSection(mainSection, network) {
     o.rmempty = false;
     o.ucisection = 'main';
 
-    // TODO(ampetelin): Can be moved to advanced settings in luci
     // Extra IPs and exclusions (main section)
     o = mainSection.taboption('basic', form.Flag, 'exclude_from_ip_enabled', _('IP for exclusion'), _('Specify local IP addresses that will never use the configured route'));
     o.default = '0';

--- a/luci-app-podkop/htdocs/luci-static/resources/view/podkop/configSection.js
+++ b/luci-app-podkop/htdocs/luci-static/resources/view/podkop/configSection.js
@@ -240,6 +240,44 @@ function createConfigSection(section, map, network) {
         return true;
     };
 
+    o = s.taboption('basic', form.Flag, 'domain_resolver_enabled', _('Domain Resolver'), _('Enable built-in DNS resolver for domains handled by this section'));
+    o.default = '0';
+    o.rmempty = false;
+    o.depends('mode', 'vpn');
+    o.ucisection = s.section;
+
+    o = s.taboption('basic', form.ListValue, 'domain_resolver_dns_type', _('Domain Resolver DNS Protocol Type'), _('Select DNS protocol for split'));
+    o.value('doh', _('DNS over HTTPS (DoH)'));
+    o.value('dot', _('DNS over TLS (DoT)'));
+    o.value('udp', _('UDP (Unprotected DNS)'));
+    o.default = 'udp';
+    o.rmempty = false;
+    o.depends('domain_resolver_enabled', '1');
+    o.ucisection = s.section;
+
+    o = s.taboption('basic', form.Value, 'domain_resolver_dns_server', _('Domain Resolver Server'), _('Select or enter DNS server address'));
+    Object.entries(constants.DNS_SERVER_OPTIONS).forEach(([key, label]) => {
+        o.value(key, _(label));
+    });
+    o.default = '8.8.8.8';
+    o.rmempty = false;
+    o.depends('domain_resolver_enabled', '1');
+    o.ucisection = s.section;
+    o.validate = function (section_id, value) {
+        if (!value) {
+            return _('DNS server address cannot be empty');
+        }
+
+        const ipRegex = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}(:[0-9]{1,5})?$/;
+        const domainRegex = /^(?:https:\/\/)?([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-zA-Z]{2,63}(:[0-9]{1,5})?(\/[^?#\s]*)?$/;
+
+        if (!ipRegex.test(value) && !domainRegex.test(value)) {
+            return _('Invalid DNS server format. Examples: 8.8.8.8 or dns.example.com or dns.example.com/nicedns for DoH');
+        }
+
+        return true;
+    };
+
     o = s.taboption('basic', form.Flag, 'community_lists_enabled', _('Community Lists'));
     o.default = '0';
     o.rmempty = false;

--- a/luci-app-podkop/htdocs/luci-static/resources/view/podkop/configSection.js
+++ b/luci-app-podkop/htdocs/luci-static/resources/view/podkop/configSection.js
@@ -246,7 +246,7 @@ function createConfigSection(section, map, network) {
     o.depends('mode', 'vpn');
     o.ucisection = s.section;
 
-    o = s.taboption('basic', form.ListValue, 'domain_resolver_dns_type', _('Domain Resolver DNS Protocol Type'), _('Select DNS protocol for split'));
+    o = s.taboption('basic', form.ListValue, 'domain_resolver_dns_type', _('DNS Protocol Type'), _('Select the DNS protocol type for the domain resolver'));
     o.value('doh', _('DNS over HTTPS (DoH)'));
     o.value('dot', _('DNS over TLS (DoT)'));
     o.value('udp', _('UDP (Unprotected DNS)'));
@@ -255,7 +255,7 @@ function createConfigSection(section, map, network) {
     o.depends('domain_resolver_enabled', '1');
     o.ucisection = s.section;
 
-    o = s.taboption('basic', form.Value, 'domain_resolver_dns_server', _('Domain Resolver Server'), _('Select or enter DNS server address'));
+    o = s.taboption('basic', form.Value, 'domain_resolver_dns_server', _('DNS Server'), _('Select or enter DNS server address'));
     Object.entries(constants.DNS_SERVER_OPTIONS).forEach(([key, label]) => {
         o.value(key, _(label));
     });

--- a/luci-app-podkop/htdocs/luci-static/resources/view/podkop/constants.js
+++ b/luci-app-podkop/htdocs/luci-static/resources/view/podkop/constants.js
@@ -62,12 +62,12 @@ const UPDATE_INTERVAL_OPTIONS = {
 };
 
 const DNS_SERVER_OPTIONS = {
-    '1.1.1.1': 'Cloudflare (1.1.1.1)',
-    '8.8.8.8': 'Google (8.8.8.8)',
-    '9.9.9.9': 'Quad9 (9.9.9.9)',
-    'dns.adguard-dns.com': 'AdGuard Default (dns.adguard-dns.com)',
-    'unfiltered.adguard-dns.com': 'AdGuard Unfiltered (unfiltered.adguard-dns.com)',
-    'family.adguard-dns.com': 'AdGuard Family (family.adguard-dns.com)'
+    '1.1.1.1': '1.1.1.1 (Cloudflare)',
+    '8.8.8.8': '8.8.8.8 (Google)',
+    '9.9.9.9': '9.9.9.9 (Quad9)',
+    'dns.adguard-dns.com': 'dns.adguard-dns.com (AdGuard Default)',
+    'unfiltered.adguard-dns.com': 'unfiltered.adguard-dns.com (AdGuard Unfiltered)',
+    'family.adguard-dns.com': 'family.adguard-dns.com (AdGuard Family)'
 };
 
 const DIAGNOSTICS_UPDATE_INTERVAL = 10000; // 10 seconds

--- a/luci-app-podkop/msgmerge.sh
+++ b/luci-app-podkop/msgmerge.sh
@@ -20,11 +20,11 @@ fi
 
 if [ -f "$POFILE" ]; then
     echo "Updating $POFILE"
-    msgmerge --update --width="$WIDTH" "$POFILE" "$POTFILE"
+    msgmerge --update --width="$WIDTH" --no-location "$POFILE" "$POTFILE"
 else
     echo "Creating new $POFILE using msginit"
     mkdir -p "$PODIR/$LANG"
-    msginit --no-translator --locale="$LANG" --width="$WIDTH" --input="$POTFILE" --output-file="$POFILE"
+    msginit --no-translator --no-location --locale="$LANG" --width="$WIDTH" --input="$POTFILE" --output-file="$POFILE"
 fi
 
 echo "Translation file for $LANG updated."

--- a/luci-app-podkop/po/ru/podkop.po
+++ b/luci-app-podkop/po/ru/podkop.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PODKOP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-30 15:18+0500\n"
+"POT-Creation-Date: 2025-10-02 19:37+0500\n"
 "PO-Revision-Date: 2025-09-30 15:18+0500\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,292 +17,204 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:8
 msgid "Additional Settings"
 msgstr "Дополнительные настройки"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:10
 msgid "Yacd enable"
 msgstr "Включить Yacd"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:15
 msgid "Exclude NTP"
 msgstr "Исключить NTP"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:15
 msgid "Allows you to exclude NTP protocol traffic from the tunnel"
 msgstr "Позволяет исключить направление трафика NTP-протокола в туннель"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:20
 msgid "QUIC disable"
 msgstr "Отключить QUIC"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:20
 msgid "For issues with the video stream"
 msgstr "Для проблем с видеопотоком"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:25
 msgid "List Update Frequency"
 msgstr "Частота обновления списков"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:25
 msgid "Select how often the lists will be updated"
 msgstr "Выберите как часто будут обновляться списки"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:33
 msgid "DNS Protocol Type"
 msgstr "Тип DNS протокола"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:33
 msgid "Select DNS protocol to use"
 msgstr "Выберите протокол DNS"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:34
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:69
 msgid "DNS over HTTPS (DoH)"
 msgstr "DNS через HTTPS (DoH)"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:35
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:70
 msgid "DNS over TLS (DoT)"
 msgstr "DNS через TLS (DoT)"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:36
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:71
 msgid "UDP (Unprotected DNS)"
 msgstr "UDP (Незащищённый DNS)"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:41
 msgid "DNS Server"
 msgstr "DNS-сервер"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:41
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:77
 msgid "Select or enter DNS server address"
 msgstr "Выберите или введите адрес DNS-сервера"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:50
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:87
 msgid "DNS server address cannot be empty"
 msgstr "Адрес DNS-сервера не может быть пустым"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:57
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:94
 msgid "Invalid DNS server format. Examples: 8.8.8.8 or dns.example.com or dns.example.com/nicedns for DoH"
 msgstr "Неверный формат DNS-сервера. Примеры: 8.8.8.8 или dns.example.com или dns.example.com/nicedns для DoH"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:63
-msgid "Split DNS"
-msgstr "Раздельный DNS"
+msgid "Bootstrap DNS server"
+msgstr "Bootstrap DNS-сервер"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:63
-msgid "DNS for the list via proxy"
-msgstr "DNS для списка через прокси"
+msgid "The DNS server used to look up the IP address of an upstream DNS server"
+msgstr "DNS-сервер, используемый для поиска IP-адреса вышестоящего DNS-сервера"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:68
-msgid "Split DNS Protocol Type"
-msgstr "Тип протокола раздельного DNS"
+msgid "Invalid DNS server format. Example: 8.8.8.8"
+msgstr "Неверный формат DNS-сервера. Пример: 8.8.8.8"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:68
-msgid "Select DNS protocol for split"
-msgstr "Выберите протокол DNS для разделения"
-
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:77
-msgid "Split DNS Server"
-msgstr "Раздельный DNS-сервер"
-
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:100
 msgid "DNS Rewrite TTL"
 msgstr "Перезапись TTL для DNS"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:100
 msgid "Time in seconds for DNS record caching (default: 60)"
 msgstr "Время в секундах для кэширования DNS записей (по умолчанию: 60)"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:106
 msgid "TTL value cannot be empty"
 msgstr "Значение TTL не может быть пустым"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:111
 msgid "TTL must be a positive number"
 msgstr "TTL должно быть положительным числом"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:117
 msgid "Config File Path"
 msgstr "Путь к файлу конфигурации"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:117
 msgid "Select path for sing-box config file. Change this ONLY if you know what you are doing"
 msgstr "Выберите путь к файлу конфигурации sing-box. Изменяйте это, ТОЛЬКО если вы знаете, что делаете"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:124
 msgid "Cache File Path"
 msgstr "Путь к файлу кэша"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:124
 msgid "Select or enter path for sing-box cache file. Change this ONLY if you know what you are doing"
 msgstr "Выберите или введите путь к файлу кеша sing-box. Изменяйте это, ТОЛЬКО если вы знаете, что делаете"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:132
 msgid "Cache file path cannot be empty"
 msgstr "Путь к файлу кэша не может быть пустым"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:136
 msgid "Path must be absolute (start with /)"
 msgstr "Путь должен быть абсолютным (начинаться с /)"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:140
 msgid "Path must end with cache.db"
 msgstr "Путь должен заканчиваться на cache.db"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:145
 msgid "Path must contain at least one directory (like /tmp/cache.db)"
 msgstr "Путь должен содержать хотя бы одну директорию (например /tmp/cache.db)"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:151
 msgid "Source Network Interface"
 msgstr "Сетевой интерфейс источника"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:151
 msgid "Select the network interface from which the traffic will originate"
 msgstr "Выберите сетевой интерфейс, с которого будет исходить трафик"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:175
 msgid "Interface monitoring"
 msgstr "Мониторинг интерфейсов"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:175
 msgid "Interface monitoring for bad WAN"
 msgstr "Мониторинг интерфейсов для плохого WAN"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:180
 msgid "Interface for monitoring"
 msgstr "Интерфейс для мониторинга"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:180
 msgid "Select the WAN interfaces to be monitored"
 msgstr "Выберите WAN интерфейсы для мониторинга"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:188
 msgid "Interface Monitoring Delay"
 msgstr "Задержка при мониторинге интерфейсов"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:188
 msgid "Delay in milliseconds before reloading podkop after interface UP"
 msgstr "Задержка в миллисекундах перед перезагрузкой podkop после поднятия интерфейса"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:195
 msgid "Delay value cannot be empty"
 msgstr "Значение задержки не может быть пустым"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:200
 msgid "Dont touch my DHCP!"
 msgstr "Не трогать мой DHCP!"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:200
 msgid "Podkop will not change the DHCP config"
 msgstr "Podkop не будет изменять конфигурацию DHCP"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:205
 msgid "Proxy download of lists"
 msgstr "Загрузка списков через прокси"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:205
 msgid "Downloading all lists via main Proxy/VPN"
 msgstr "Загрузка всех списков через основной прокси/VPN"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:212
 msgid "IP for exclusion"
 msgstr "IP для исключения"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:212
 msgid "Specify local IP addresses that will never use the configured route"
 msgstr "Укажите локальные IP-адреса, которые никогда не будут использовать настроенный маршрут"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:217
-#: htdocs/luci-static/resources/view/podkop/configSection.js:536
 msgid "Local IPs"
 msgstr "Локальные IP адреса"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:217
-#: htdocs/luci-static/resources/view/podkop/configSection.js:536
 msgid "Enter valid IPv4 addresses"
 msgstr "Введите действительные IPv4-адреса"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:225
-#: htdocs/luci-static/resources/view/podkop/configSection.js:544
 msgid "Invalid IP format. Use format: X.X.X.X (like 192.168.1.1)"
 msgstr "Неверный формат IP. Используйте формат: X.X.X.X (например: 192.168.1.1)"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:229
-#: htdocs/luci-static/resources/view/podkop/configSection.js:450
-#: htdocs/luci-static/resources/view/podkop/configSection.js:548
 msgid "IP address parts must be between 0 and 255"
 msgstr "Части IP-адреса должны быть между 0 и 255"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:234
 msgid "Mixed enable"
 msgstr "Включить смешанный режим"
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:234
 msgid "Browser port: 2080"
 msgstr "Порт браузера: 2080"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:13
 msgid "URL must use one of the following protocols: "
 msgstr "URL должен использовать один из следующих протоколов: "
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:17
 msgid "Invalid URL format"
 msgstr "Неверный формат URL"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:24
 msgid "Basic Settings"
 msgstr "Основные настройки"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:26
 msgid "Connection Type"
 msgstr "Тип подключения"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:26
 msgid "Select between VPN and Proxy connection methods for traffic routing"
 msgstr "Выберите между VPN и Proxy методами для маршрутизации трафика"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:32
 msgid "Configuration Type"
 msgstr "Тип конфигурации"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:32
 msgid "Select how to configure the proxy"
 msgstr "Выберите способ настройки прокси"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:33
 msgid "Connection URL"
 msgstr "URL подключения"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:34
 msgid "Outbound Config"
 msgstr "Конфигурация Outbound"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:35
 msgid "URLTest"
 msgstr "URLTest"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:40
 msgid "Proxy Configuration URL"
 msgstr "URL конфигурации прокси"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:64
 msgid "Current config: "
 msgstr "Текущая конфигурация: "
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:67
-#: htdocs/luci-static/resources/view/podkop/configSection.js:71
-#: htdocs/luci-static/resources/view/podkop/configSection.js:77
 msgid "Config without description"
 msgstr "Конфигурация без описания"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:82
 msgid ""
 "Enter connection string starting with vless:// or ss:// for proxy configuration. Add comments with // for backup "
 "configs"
@@ -310,150 +222,121 @@ msgstr ""
 "Введите строку подключения, начинающуюся с vless:// или ss:// для настройки прокси. Добавляйте комментарии с // для "
 "сохранения других конфигураций"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:100
 msgid "No active configuration found. At least one non-commented line is required."
 msgstr "Активная конфигурация не найдена. Требуется хотя бы одна незакомментированная строка."
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:104
 msgid "URL must start with vless:// or ss://"
 msgstr "URL должен начинаться с vless:// или ss://"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:116
-#: htdocs/luci-static/resources/view/podkop/configSection.js:121
 msgid "Invalid Shadowsocks URL format: missing method and password separator \":\""
 msgstr "Неверный формат URL Shadowsocks: отсутствует разделитель метода и пароля \":\""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:125
 msgid "Invalid Shadowsocks URL format"
 msgstr "Неверный формат URL Shadowsocks"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:130
 msgid "Invalid Shadowsocks URL: missing server address"
 msgstr "Неверный URL Shadowsocks: отсутствует адрес сервера"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:132
 msgid "Invalid Shadowsocks URL: missing server"
 msgstr "Неверный URL Shadowsocks: отсутствует сервер"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:134
 msgid "Invalid Shadowsocks URL: missing port"
 msgstr "Неверный URL Shadowsocks: отсутствует порт"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:137
-#: htdocs/luci-static/resources/view/podkop/configSection.js:157
 msgid "Invalid port number. Must be between 1 and 65535"
 msgstr "Неверный номер порта. Должен быть между 1 и 65535"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:140
 msgid "Invalid Shadowsocks URL: missing or invalid server/port format"
 msgstr "Неверный URL Shadowsocks: отсутствует или неверный формат сервера/порта"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:146
 msgid "Invalid VLESS URL: missing UUID"
 msgstr "Неверный URL VLESS: отсутствует UUID"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:150
 msgid "Invalid VLESS URL: missing server address"
 msgstr "Неверный URL VLESS: отсутствует адрес сервера"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:152
 msgid "Invalid VLESS URL: missing server"
 msgstr "Неверный URL VLESS: отсутствует сервер"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:154
 msgid "Invalid VLESS URL: missing port"
 msgstr "Неверный URL VLESS: отсутствует порт"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:160
 msgid "Invalid VLESS URL: missing or invalid server/port format"
 msgstr "Неверный URL VLESS: отсутствует или неверный формат сервера/порта"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:164
 msgid "Invalid VLESS URL: missing query parameters"
 msgstr "Неверный URL VLESS: отсутствуют параметры запроса"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:170
 msgid "Invalid VLESS URL: type must be one of tcp, raw, udp, grpc, http, ws"
 msgstr "Неверный URL VLESS: тип должен быть одним из tcp, raw, udp, grpc, http, ws"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:176
 msgid "Invalid VLESS URL: security must be one of tls, reality, none"
 msgstr "Неверный URL VLESS: security должен быть одним из tls, reality, none"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:180
 msgid "Invalid VLESS URL: missing pbk parameter for reality security"
 msgstr "Неверный URL VLESS: отсутствует параметр pbk для security reality"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:181
 msgid "Invalid VLESS URL: missing fp parameter for reality security"
 msgstr "Неверный URL VLESS: отсутствует параметр fp для security reality"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:188
 msgid "Invalid URL format: "
 msgstr "Неверный формат URL: "
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:192
 msgid "Outbound Configuration"
 msgstr "Конфигурация исходящего соединения"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:192
 msgid "Enter complete outbound configuration in JSON format"
 msgstr "Введите полную конфигурацию исходящего соединения в формате JSON"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:201
 msgid "JSON must contain at least type, server and server_port fields"
 msgstr "JSON должен содержать как минимум поля type, server и server_port"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:205
 msgid "Invalid JSON format"
 msgstr "Неверный формат JSON"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:209
 msgid "URLTest Proxy Links"
 msgstr "Ссылки прокси для URLTest"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:214
 msgid "Shadowsocks UDP over TCP"
 msgstr "Shadowsocks UDP через TCP"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:214
 msgid "Apply for SS2022"
 msgstr "Применить для SS2022"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:220
 msgid "Network Interface"
 msgstr "Сетевой интерфейс"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:220
 msgid "Select network interface for VPN connection"
 msgstr "Выберите сетевой интерфейс для VPN подключения"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:243
+msgid "Domain Resolver"
+msgstr "Резолвер доменов"
+
+msgid "Enable built-in DNS resolver for domains handled by this section"
+msgstr "Включить встроенный DNS-резолвер для доменов, обрабатываемых в этом разделе"
+
+msgid "Select the DNS protocol type for the domain resolver"
+msgstr "Выберите протокол DNS для резолвера доменов"
+
 msgid "Community Lists"
 msgstr "Списки сообщества"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:248
 msgid "Service List"
 msgstr "Список сервисов"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:248
 msgid "Select predefined service for routing"
 msgstr "Выберите предустановленные сервисы для маршрутизации"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:276
 msgid "Regional options cannot be used together"
 msgstr "Нельзя использовать несколько региональных опций"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:277
 #, javascript-format
 msgid "Warning: %s cannot be used together with %s. Previous selections have been removed."
 msgstr "Предупреждение: %s нельзя использовать вместе с %s. Предыдущие варианты были удалены."
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:287
 msgid "Russia inside restrictions"
 msgstr "Ограничения Russia inside"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:288
 #, javascript-format
 msgid ""
 "Warning: Russia inside can only be used with %s. %s already in Russia inside and have been removed from selection."
@@ -461,144 +344,105 @@ msgstr ""
 "Внимание: \"Russia inside\" может использоваться только с %s. %s уже находится в \"Russia inside\" и был удален из "
 "выбора."
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:310
 msgid "User Domain List Type"
 msgstr "Тип пользовательского списка доменов"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:310
 msgid "Select how to add your custom domains"
 msgstr "Выберите способ добавления пользовательских доменов"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:311
-#: htdocs/luci-static/resources/view/podkop/configSection.js:427
 msgid "Disabled"
 msgstr "Отключено"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:312
-#: htdocs/luci-static/resources/view/podkop/configSection.js:428
 msgid "Dynamic List"
 msgstr "Динамический список"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:313
 msgid "Text List"
 msgstr "Текстовый список"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:318
 msgid "User Domains"
 msgstr "Пользовательские домены"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:318
 msgid "Enter domain names without protocols (example: sub.example.com or example.com)"
-msgstr ""
+msgstr "Введите доменные имена без указания протоколов (например: sub.example.com или example.com)"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:327
 msgid "Invalid domain format. Enter domain without protocol (example: sub.example.com or ru)"
 msgstr "Введите имена доменов без протоколов (пример: sub.example.com или example.com)"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:332
 msgid "User Domains List"
 msgstr "Список пользовательских доменов"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:332
 msgid "Enter domain names separated by comma, space or newline. You can add comments after //"
 msgstr ""
 "Введите имена доменов, разделяя их запятой, пробелом или с новой строки. Вы можете добавлять комментарии после //"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:360
 #, javascript-format
 msgid "Invalid domain format: %s. Enter domain without protocol"
 msgstr "Неверный формат домена: %s. Введите домен без протокола"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:367
 msgid "At least one valid domain must be specified. Comments-only content is not allowed."
 msgstr ""
 "Должен быть указан хотя бы один действительный домен. Содержимое, состоящее только из комментариев, не допускается."
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:373
 msgid "Local Domain Lists"
 msgstr "Локальные списки доменов"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:373
-#: htdocs/luci-static/resources/view/podkop/configSection.js:407
 msgid "Use the list from the router filesystem"
 msgstr "Использовать список из файловой системы роутера"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:378
 msgid "Local Domain List Paths"
 msgstr "Пути к локальным спискам доменов"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:378
-#: htdocs/luci-static/resources/view/podkop/configSection.js:412
 msgid "Enter the list file path"
 msgstr "Введите путь к файлу списка"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:387
-#: htdocs/luci-static/resources/view/podkop/configSection.js:421
 msgid "Invalid path format. Path must start with \"/\" and contain valid characters"
 msgstr "Неверный формат пути. Путь должен начинаться с \"/\" и содержать допустимые символы"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:392
 msgid "Remote Domain Lists"
 msgstr "Удаленные списки доменов"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:392
 msgid "Download and use domain lists from remote URLs"
 msgstr "Загрузка и использование списков доменов с удаленных URL"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:397
 msgid "Remote Domain URLs"
 msgstr "URL удаленных доменов"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:397
-#: htdocs/luci-static/resources/view/podkop/configSection.js:521
 msgid "Enter full URLs starting with http:// or https://"
 msgstr "Введите полные URL, начинающиеся с http:// или https://"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:407
 msgid "Local Subnet Lists"
 msgstr "Локальные списки подсетей"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:412
 msgid "Local Subnet List Paths"
 msgstr "Пути к локальным спискам подсетей"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:426
 msgid "User Subnet List Type"
 msgstr "Тип пользовательского списка подсетей"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:426
 msgid "Select how to add your custom subnets"
 msgstr "Выберите способ добавления пользовательских подсетей"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:429
 msgid "Text List (comma/space/newline separated)"
 msgstr "Текстовый список (разделенный запятыми/пробелами/новыми строками)"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:434
 msgid "User Subnets"
 msgstr "Пользовательские подсети"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:434
 msgid "Enter subnets in CIDR notation (example: 103.21.244.0/22) or single IP addresses"
 msgstr "Введите подсети в нотации CIDR (пример: 103.21.244.0/22) или отдельные IP-адреса"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:442
 msgid "Invalid format. Use format: X.X.X.X or X.X.X.X/Y"
 msgstr "Неверный формат. Используйте формат: X.X.X.X или X.X.X.X/Y"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:445
 msgid "IP address 0.0.0.0 is not allowed"
 msgstr "IP адрес не может быть 0.0.0.0"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:454
 msgid "CIDR must be between 0 and 32"
 msgstr "CIDR должен быть между 0 и 32"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:459
 msgid "User Subnets List"
 msgstr "Список пользовательских подсетей"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:459
 msgid ""
 "Enter subnets in CIDR notation or single IP addresses, separated by comma, space or newline. You can add comments "
 "after //"
@@ -606,254 +450,178 @@ msgstr ""
 "Введите подсети в нотации CIDR или отдельные IP-адреса, разделенные запятой, пробелом или новой строкой. Вы можете "
 "добавлять комментарии после //"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:487
 #, javascript-format
 msgid "Invalid format: %s. Use format: X.X.X.X or X.X.X.X/Y"
 msgstr "Неверный формат: %s. Используйте формат: X.X.X.X или X.X.X.X/Y"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:495
 #, javascript-format
 msgid "IP parts must be between 0 and 255 in: %s"
 msgstr "Части IP-адреса должны быть между 0 и 255 в: %s"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:502
 #, javascript-format
 msgid "CIDR must be between 0 and 32 in: %s"
 msgstr "CIDR должен быть между 0 и 32 в: %s"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:510
 msgid "At least one valid subnet or IP must be specified. Comments-only content is not allowed."
 msgstr ""
 "Должна быть указана хотя бы одна действительная подсеть или IP. Содержимое, состоящее только из комментариев, не "
 "допускается."
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:516
 msgid "Remote Subnet Lists"
 msgstr "Удаленные списки подсетей"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:516
 msgid "Download and use subnet lists from remote URLs"
 msgstr "Загрузка и использование списков подсетей с удаленных URL"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:521
 msgid "Remote Subnet URLs"
 msgstr "URL удаленных подсетей"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:531
 msgid "IP for full redirection"
 msgstr "IP для полного перенаправления"
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:531
 msgid "Specify local IP addresses whose traffic will always use the configured route"
 msgstr "Укажите локальные IP-адреса, трафик которых всегда будет использовать настроенный маршрут"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:121
 msgid "Copied!"
 msgstr "Скопировано!"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:124
 msgid "Failed to copy: "
 msgstr "Не удалось скопировать: "
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:272
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:303
 msgid "Copy to Clipboard"
 msgstr "Копировать в буфер обмена"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:276
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:307
 msgid "Close"
 msgstr "Закрыть"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:293
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:439
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:579
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:580
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:581
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:582
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:583
 msgid "Loading..."
 msgstr "Загрузка..."
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:326
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:388
 msgid "No output"
 msgstr "Нет вывода"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:338
 msgid "FakeIP is working in browser!"
 msgstr "FakeIP работает в браузере!"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:340
 msgid "FakeIP is not working in browser"
 msgstr "FakeIP не работает в браузере"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:341
 msgid "Check DNS server on current device (PC, phone)"
 msgstr "Проверьте DNS сервер на текущем устройстве (ПК, телефон)"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:342
 msgid "Its must be router!"
 msgstr "Это должен быть роутер!"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:355
 msgid "Proxy working correctly"
 msgstr "Прокси работает корректно"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:356
 msgid "Direct IP: "
 msgstr "Прямой IP: "
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:357
 msgid "Proxy IP: "
 msgstr "Прокси IP: "
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:359
 msgid "Proxy is not working - same IP for both domains"
 msgstr "Прокси не работает - одинаковый IP для обоих доменов"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:360
 msgid "IP: "
 msgstr "IP: "
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:362
 msgid "Proxy check failed"
 msgstr "Проверка прокси не удалась"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:368
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:373
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:378
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:382
 msgid "Check failed: "
 msgstr "Проверка не удалась: "
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:368
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:373
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:378
 msgid "timeout"
 msgstr "таймаут"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:393
 msgid "Error: "
 msgstr "Ошибка: "
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:461
 msgid "Podkop Status"
 msgstr "Статус Podkop"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:486
 msgid "Global check"
 msgstr "Глобальная проверка"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:488
 msgid "Click here for all the info"
 msgstr "Нажмите для просмотра всей информации"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:496
 msgid "Update Lists"
 msgstr "Обновить списки"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:498
 msgid "Lists Update Results"
 msgstr "Результаты обновления списков"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:506
 msgid "Sing-box Status"
 msgstr "Статус Sing-box"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:527
 msgid "Check NFT Rules"
 msgstr "Проверить правила NFT"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:529
 msgid "NFT Rules"
 msgstr "Правила NFT"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:532
 msgid "Check DNSMasq"
 msgstr "Проверить DNSMasq"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:534
 msgid "DNSMasq Configuration"
 msgstr "Конфигурация DNSMasq"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:542
 msgid "FakeIP Status"
 msgstr "Статус FakeIP"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:555
 msgid "DNS Status"
 msgstr "Статус DNS"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:564
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:780
 msgid "Main config"
 msgstr "Основная конфигурация"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:575
 msgid "Version Information"
 msgstr "Информация о версии"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:579
 msgid "Podkop: "
 msgstr "Podkop: "
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:580
 msgid "LuCI App: "
 msgstr "LuCI App: "
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:581
 msgid "Sing-box: "
 msgstr "Sing-box: "
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:582
 msgid "OpenWrt Version: "
 msgstr "Версия OpenWrt: "
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:583
 msgid "Device Model: "
 msgstr "Модель устройства: "
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:694
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:700
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:706
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:719
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:720
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:729
 msgid "works in browser"
 msgstr "работает в браузере"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:729
 msgid "does not work in browser"
-msgstr ""
+msgstr "не работает в браузере"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:738
 msgid "works on router"
 msgstr "не работает в браузере"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:738
 msgid "does not work on router"
 msgstr "не работает на роутере"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:793
 msgid "Config: "
 msgstr "Конфигурация: "
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:807
 msgid "Diagnostics"
 msgstr "Диагностика"
 
-#: htdocs/luci-static/resources/view/podkop/diagnosticTab.js:818
 msgid "Podkop"
 msgstr "Podkop"
 
-#: htdocs/luci-static/resources/view/podkop/podkop.js:84
 msgid "Extra configurations"
 msgstr "Дополнительные конфигурации"
 
-#: htdocs/luci-static/resources/view/podkop/podkop.js:87
 msgid "Add Section"
 msgstr "Добавить раздел"

--- a/luci-app-podkop/po/templates/podkop.pot
+++ b/luci-app-podkop/po/templates/podkop.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PODKOP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-30 15:18+0500\n"
+"POT-Creation-Date: 2025-10-02 19:37+0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -50,6 +50,7 @@ msgid "Select how often the lists will be updated"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/podkop/additionalTab.js:33
+#: htdocs/luci-static/resources/view/podkop/configSection.js:249
 msgid "DNS Protocol Type"
 msgstr ""
 
@@ -58,193 +59,187 @@ msgid "Select DNS protocol to use"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/podkop/additionalTab.js:34
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:69
+#: htdocs/luci-static/resources/view/podkop/configSection.js:250
 msgid "DNS over HTTPS (DoH)"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/podkop/additionalTab.js:35
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:70
+#: htdocs/luci-static/resources/view/podkop/configSection.js:251
 msgid "DNS over TLS (DoT)"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/podkop/additionalTab.js:36
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:71
+#: htdocs/luci-static/resources/view/podkop/configSection.js:252
 msgid "UDP (Unprotected DNS)"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/podkop/additionalTab.js:41
+#: htdocs/luci-static/resources/view/podkop/configSection.js:258
 msgid "DNS Server"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/podkop/additionalTab.js:41
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:77
+#: htdocs/luci-static/resources/view/podkop/configSection.js:258
 msgid "Select or enter DNS server address"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/podkop/additionalTab.js:50
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:87
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:77
+#: htdocs/luci-static/resources/view/podkop/configSection.js:268
 msgid "DNS server address cannot be empty"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/podkop/additionalTab.js:57
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:94
+#: htdocs/luci-static/resources/view/podkop/configSection.js:275
 msgid "Invalid DNS server format. Examples: 8.8.8.8 or dns.example.com or dns.example.com/nicedns for DoH"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/podkop/additionalTab.js:63
-msgid "Split DNS"
+msgid "Bootstrap DNS server"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/podkop/additionalTab.js:63
-msgid "DNS for the list via proxy"
+msgid "The DNS server used to look up the IP address of an upstream DNS server"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:68
-msgid "Split DNS Protocol Type"
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:83
+msgid "Invalid DNS server format. Example: 8.8.8.8"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:68
-msgid "Select DNS protocol for split"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:77
-msgid "Split DNS Server"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:100
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:89
 msgid "DNS Rewrite TTL"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:100
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:89
 msgid "Time in seconds for DNS record caching (default: 60)"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:106
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:95
 msgid "TTL value cannot be empty"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:111
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:100
 msgid "TTL must be a positive number"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:117
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:106
 msgid "Config File Path"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:117
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:106
 msgid "Select path for sing-box config file. Change this ONLY if you know what you are doing"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:124
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:113
 msgid "Cache File Path"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:124
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:113
 msgid "Select or enter path for sing-box cache file. Change this ONLY if you know what you are doing"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:132
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:121
 msgid "Cache file path cannot be empty"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:136
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:125
 msgid "Path must be absolute (start with /)"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:140
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:129
 msgid "Path must end with cache.db"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:145
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:134
 msgid "Path must contain at least one directory (like /tmp/cache.db)"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:151
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:140
 msgid "Source Network Interface"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:151
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:140
 msgid "Select the network interface from which the traffic will originate"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:175
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:164
 msgid "Interface monitoring"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:175
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:164
 msgid "Interface monitoring for bad WAN"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:180
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:169
 msgid "Interface for monitoring"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:180
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:169
 msgid "Select the WAN interfaces to be monitored"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:188
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:177
 msgid "Interface Monitoring Delay"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:188
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:177
 msgid "Delay in milliseconds before reloading podkop after interface UP"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:195
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:184
 msgid "Delay value cannot be empty"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:200
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:189
 msgid "Dont touch my DHCP!"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:200
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:189
 msgid "Podkop will not change the DHCP config"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:205
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:194
 msgid "Proxy download of lists"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:205
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:194
 msgid "Downloading all lists via main Proxy/VPN"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:212
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:200
 msgid "IP for exclusion"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:212
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:200
 msgid "Specify local IP addresses that will never use the configured route"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:217
-#: htdocs/luci-static/resources/view/podkop/configSection.js:536
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:205
+#: htdocs/luci-static/resources/view/podkop/configSection.js:574
 msgid "Local IPs"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:217
-#: htdocs/luci-static/resources/view/podkop/configSection.js:536
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:205
+#: htdocs/luci-static/resources/view/podkop/configSection.js:574
 msgid "Enter valid IPv4 addresses"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:225
-#: htdocs/luci-static/resources/view/podkop/configSection.js:544
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:213
+#: htdocs/luci-static/resources/view/podkop/configSection.js:582
 msgid "Invalid IP format. Use format: X.X.X.X (like 192.168.1.1)"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:229
-#: htdocs/luci-static/resources/view/podkop/configSection.js:450
-#: htdocs/luci-static/resources/view/podkop/configSection.js:548
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:217
+#: htdocs/luci-static/resources/view/podkop/configSection.js:488
+#: htdocs/luci-static/resources/view/podkop/configSection.js:586
 msgid "IP address parts must be between 0 and 255"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:234
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:222
 msgid "Mixed enable"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/additionalTab.js:234
+#: htdocs/luci-static/resources/view/podkop/additionalTab.js:222
 msgid "Browser port: 2080"
 msgstr ""
 
@@ -427,213 +422,225 @@ msgid "Select network interface for VPN connection"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/podkop/configSection.js:243
+msgid "Domain Resolver"
+msgstr ""
+
+#: htdocs/luci-static/resources/view/podkop/configSection.js:243
+msgid "Enable built-in DNS resolver for domains handled by this section"
+msgstr ""
+
+#: htdocs/luci-static/resources/view/podkop/configSection.js:249
+msgid "Select the DNS protocol type for the domain resolver"
+msgstr ""
+
+#: htdocs/luci-static/resources/view/podkop/configSection.js:281
 msgid "Community Lists"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:248
+#: htdocs/luci-static/resources/view/podkop/configSection.js:286
 msgid "Service List"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:248
+#: htdocs/luci-static/resources/view/podkop/configSection.js:286
 msgid "Select predefined service for routing"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:276
+#: htdocs/luci-static/resources/view/podkop/configSection.js:314
 msgid "Regional options cannot be used together"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:277
+#: htdocs/luci-static/resources/view/podkop/configSection.js:315
 #, javascript-format
 msgid "Warning: %s cannot be used together with %s. Previous selections have been removed."
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:287
+#: htdocs/luci-static/resources/view/podkop/configSection.js:325
 msgid "Russia inside restrictions"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:288
+#: htdocs/luci-static/resources/view/podkop/configSection.js:326
 #, javascript-format
 msgid ""
 "Warning: Russia inside can only be used with %s. %s already in Russia inside and have been removed from selection."
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:310
+#: htdocs/luci-static/resources/view/podkop/configSection.js:348
 msgid "User Domain List Type"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:310
+#: htdocs/luci-static/resources/view/podkop/configSection.js:348
 msgid "Select how to add your custom domains"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:311
-#: htdocs/luci-static/resources/view/podkop/configSection.js:427
+#: htdocs/luci-static/resources/view/podkop/configSection.js:349
+#: htdocs/luci-static/resources/view/podkop/configSection.js:465
 msgid "Disabled"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:312
-#: htdocs/luci-static/resources/view/podkop/configSection.js:428
+#: htdocs/luci-static/resources/view/podkop/configSection.js:350
+#: htdocs/luci-static/resources/view/podkop/configSection.js:466
 msgid "Dynamic List"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:313
+#: htdocs/luci-static/resources/view/podkop/configSection.js:351
 msgid "Text List"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:318
+#: htdocs/luci-static/resources/view/podkop/configSection.js:356
 msgid "User Domains"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:318
+#: htdocs/luci-static/resources/view/podkop/configSection.js:356
 msgid "Enter domain names without protocols (example: sub.example.com or example.com)"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:327
+#: htdocs/luci-static/resources/view/podkop/configSection.js:365
 msgid "Invalid domain format. Enter domain without protocol (example: sub.example.com or ru)"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:332
+#: htdocs/luci-static/resources/view/podkop/configSection.js:370
 msgid "User Domains List"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:332
+#: htdocs/luci-static/resources/view/podkop/configSection.js:370
 msgid "Enter domain names separated by comma, space or newline. You can add comments after //"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:360
+#: htdocs/luci-static/resources/view/podkop/configSection.js:398
 #, javascript-format
 msgid "Invalid domain format: %s. Enter domain without protocol"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:367
+#: htdocs/luci-static/resources/view/podkop/configSection.js:405
 msgid "At least one valid domain must be specified. Comments-only content is not allowed."
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:373
+#: htdocs/luci-static/resources/view/podkop/configSection.js:411
 msgid "Local Domain Lists"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:373
-#: htdocs/luci-static/resources/view/podkop/configSection.js:407
+#: htdocs/luci-static/resources/view/podkop/configSection.js:411
+#: htdocs/luci-static/resources/view/podkop/configSection.js:445
 msgid "Use the list from the router filesystem"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:378
+#: htdocs/luci-static/resources/view/podkop/configSection.js:416
 msgid "Local Domain List Paths"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:378
-#: htdocs/luci-static/resources/view/podkop/configSection.js:412
+#: htdocs/luci-static/resources/view/podkop/configSection.js:416
+#: htdocs/luci-static/resources/view/podkop/configSection.js:450
 msgid "Enter the list file path"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:387
-#: htdocs/luci-static/resources/view/podkop/configSection.js:421
+#: htdocs/luci-static/resources/view/podkop/configSection.js:425
+#: htdocs/luci-static/resources/view/podkop/configSection.js:459
 msgid "Invalid path format. Path must start with \"/\" and contain valid characters"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:392
+#: htdocs/luci-static/resources/view/podkop/configSection.js:430
 msgid "Remote Domain Lists"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:392
+#: htdocs/luci-static/resources/view/podkop/configSection.js:430
 msgid "Download and use domain lists from remote URLs"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:397
+#: htdocs/luci-static/resources/view/podkop/configSection.js:435
 msgid "Remote Domain URLs"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:397
-#: htdocs/luci-static/resources/view/podkop/configSection.js:521
+#: htdocs/luci-static/resources/view/podkop/configSection.js:435
+#: htdocs/luci-static/resources/view/podkop/configSection.js:559
 msgid "Enter full URLs starting with http:// or https://"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:407
+#: htdocs/luci-static/resources/view/podkop/configSection.js:445
 msgid "Local Subnet Lists"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:412
+#: htdocs/luci-static/resources/view/podkop/configSection.js:450
 msgid "Local Subnet List Paths"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:426
+#: htdocs/luci-static/resources/view/podkop/configSection.js:464
 msgid "User Subnet List Type"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:426
+#: htdocs/luci-static/resources/view/podkop/configSection.js:464
 msgid "Select how to add your custom subnets"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:429
+#: htdocs/luci-static/resources/view/podkop/configSection.js:467
 msgid "Text List (comma/space/newline separated)"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:434
+#: htdocs/luci-static/resources/view/podkop/configSection.js:472
 msgid "User Subnets"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:434
+#: htdocs/luci-static/resources/view/podkop/configSection.js:472
 msgid "Enter subnets in CIDR notation (example: 103.21.244.0/22) or single IP addresses"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:442
+#: htdocs/luci-static/resources/view/podkop/configSection.js:480
 msgid "Invalid format. Use format: X.X.X.X or X.X.X.X/Y"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:445
+#: htdocs/luci-static/resources/view/podkop/configSection.js:483
 msgid "IP address 0.0.0.0 is not allowed"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:454
+#: htdocs/luci-static/resources/view/podkop/configSection.js:492
 msgid "CIDR must be between 0 and 32"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:459
+#: htdocs/luci-static/resources/view/podkop/configSection.js:497
 msgid "User Subnets List"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:459
+#: htdocs/luci-static/resources/view/podkop/configSection.js:497
 msgid ""
 "Enter subnets in CIDR notation or single IP addresses, separated by comma, space or newline. You can add comments "
 "after //"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:487
+#: htdocs/luci-static/resources/view/podkop/configSection.js:525
 #, javascript-format
 msgid "Invalid format: %s. Use format: X.X.X.X or X.X.X.X/Y"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:495
+#: htdocs/luci-static/resources/view/podkop/configSection.js:533
 #, javascript-format
 msgid "IP parts must be between 0 and 255 in: %s"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:502
+#: htdocs/luci-static/resources/view/podkop/configSection.js:540
 #, javascript-format
 msgid "CIDR must be between 0 and 32 in: %s"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:510
+#: htdocs/luci-static/resources/view/podkop/configSection.js:548
 msgid "At least one valid subnet or IP must be specified. Comments-only content is not allowed."
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:516
+#: htdocs/luci-static/resources/view/podkop/configSection.js:554
 msgid "Remote Subnet Lists"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:516
+#: htdocs/luci-static/resources/view/podkop/configSection.js:554
 msgid "Download and use subnet lists from remote URLs"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:521
+#: htdocs/luci-static/resources/view/podkop/configSection.js:559
 msgid "Remote Subnet URLs"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:531
+#: htdocs/luci-static/resources/view/podkop/configSection.js:569
 msgid "IP for full redirection"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/podkop/configSection.js:531
+#: htdocs/luci-static/resources/view/podkop/configSection.js:569
 msgid "Specify local IP addresses whose traffic will always use the configured route"
 msgstr ""
 

--- a/podkop/files/usr/bin/podkop
+++ b/podkop/files/usr/bin/podkop
@@ -576,16 +576,6 @@ list_update() {
     fi
 }
 
-find_working_resolver() {
-    for resolver in $DNS_RESOLVERS; do
-        if nslookup -timeout=2 $FAKEIP_TEST_DOMAIN $resolver > /dev/null 2>&1; then
-            echo "$resolver"
-            return 0
-        fi
-    done
-    return 1
-}
-
 # sing-box funcs
 
 sing_box_uci() {
@@ -709,7 +699,7 @@ configure_outbound_handler() {
                 else
                     outbound_tags="$outbound_tags,$outbound_tag"
                 fi
-                i=$((i+1))
+                i=$((i + 1))
             done
 
             urltest_tag="$(get_outbound_tag_by_section "$section-urltest")"
@@ -749,53 +739,22 @@ configure_outbound_handler() {
 
 sing_box_configure_dns() {
     log "Configure the DNS section of a sing-box JSON configuration"
-    local split_dns_enabled final_dns_server
-    config_get_bool split_dns_enabled "main" "split_dns_enabled" 0
-    if [ "$split_dns_enabled" -eq 1 ]; then
-        final_dns_server="$SB_SPLIT_DNS_SERVER_TAG"
-    else
-        final_dns_server="$SB_DNS_SERVER_TAG"
-    fi
-    config=$(sing_box_cm_configure_dns "$config" "$final_dns_server" "ipv4_only" true)
+    config=$(sing_box_cm_configure_dns "$config" "$SB_DNS_SERVER_TAG" "ipv4_only" true)
 
-    local dns_type dns_server split_dns_type split_dns_server dns_server_address split_dns_server_address
+    log "Adding DNS Servers" "debug"
+    local dns_type dns_server bootstrap_dns_server dns_server_address dns_domain_resolver
     config_get dns_type "main" "dns_type" "doh"
     config_get dns_server "main" "dns_server" "1.1.1.1"
-    config_get split_dns_type "main" "split_dns_type" "udp"
-    config_get split_dns_server "main" "split_dns_server" "1.1.1.1"
+    config_get bootstrap_dns_server "main" "bootstrap_dns_server" "77.88.8.8"
+
     dns_server_address=$(url_get_host "$dns_server")
-    split_dns_server_address=$(url_get_host "$split_dns_server")
-
-    local need_dns_domain_resolver=0
-    if ! is_ipv4 "$dns_server_address" || ! is_ipv4 "$split_dns_server_address"; then
-        need_dns_domain_resolver=1
+    if ! is_ipv4 "$dns_server_address"; then
+        dns_domain_resolver=$SB_BOOTSTRAP_SERVER_TAG
     fi
 
-    log "Adding DNS Servers"
-    config=$(sing_box_cm_add_fakeip_dns_server "$config" "$SB_FAKEIP_DNS_SERVER_TAG" "$SB_FAKEIP_INET4_RANGE")
-
-    local dns_domain_resolver
-    if [ "$need_dns_domain_resolver" -eq 1 ]; then
-        log "One of the DNS server addresses is a domain. Searching for a working DNS server..."
-        dns_domain_resolver=$(find_working_resolver)
-        if [ -z "$dns_domain_resolver" ]; then
-            log "Working DNS server not found, using default DNS server"
-            dns_domain_resolver="1.1.1.1"
-        else
-            log "Working DNS server has been found: $dns_domain_resolver"
-        fi
-        config=$(sing_box_cm_add_udp_dns_server "$config" "$SB_DNS_DOMAIN_RESOLVER_TAG" "$dns_domain_resolver" 53)
-        dns_domain_resolver="$SB_DNS_DOMAIN_RESOLVER_TAG"
-    fi
-
+    config=$(sing_box_cm_add_udp_dns_server "$config" "$SB_BOOTSTRAP_SERVER_TAG" "$bootstrap_dns_server" 53)
     config=$(sing_box_cf_add_dns_server "$config" "$dns_type" "$SB_DNS_SERVER_TAG" "$dns_server" "$dns_domain_resolver")
-
-    if [ "$split_dns_enabled" -eq 1 ]; then
-        config=$(
-            sing_box_cf_add_dns_server "$config" "$split_dns_type" "$SB_SPLIT_DNS_SERVER_TAG" "$split_dns_server" \
-                "$dns_domain_resolver" "$SB_MAIN_OUTBOUND_TAG"
-        )
-    fi
+    config=$(sing_box_cm_add_fakeip_dns_server "$config" "$SB_FAKEIP_DNS_SERVER_TAG" "$SB_FAKEIP_INET4_RANGE")
 
     log "Adding DNS Rules"
     local rewrite_ttl service_domains
@@ -807,11 +766,6 @@ sing_box_configure_dns() {
     config=$(sing_box_cm_patch_dns_route_rule "$config" "$SB_FAKEIP_DNS_RULE_TAG" "rewrite_ttl" "$rewrite_ttl")
     service_domains=$(comma_string_to_json_array "$FAKEIP_TEST_DOMAIN,$CHECK_PROXY_IP_DOMAIN")
     config=$(sing_box_cm_patch_dns_route_rule "$config" "$SB_FAKEIP_DNS_RULE_TAG" "domain" "$service_domains")
-    if [ "$split_dns_enabled" -eq 1 ]; then
-        config=$(sing_box_cm_add_dns_route_rule "$config" "$SB_DNS_SERVER_TAG" "$SB_INVERT_FAKEIP_DNS_RULE_TAG")
-        config=$(sing_box_cm_patch_dns_route_rule "$config" "$SB_INVERT_FAKEIP_DNS_RULE_TAG" "invert" true)
-        config=$(sing_box_cm_patch_dns_route_rule "$config" "$SB_INVERT_FAKEIP_DNS_RULE_TAG" "domain" "$service_domains")
-    fi
 }
 
 sing_box_configure_route() {
@@ -990,7 +944,9 @@ prepare_common_ruleset() {
         config=$(sing_box_cm_add_local_ruleset "$config" "$ruleset_tag" "source" "$ruleset_filepath")
         config=$(sing_box_cm_patch_route_rule "$config" "$route_rule_tag" "rule_set" "$ruleset_tag")
         case "$type" in
-        domains) _add_ruleset_to_dns_rules "$ruleset_tag" "$route_rule_tag" ;;
+        domains)
+            config=$(sing_box_cm_patch_dns_route_rule "$config" "$SB_FAKEIP_DNS_RULE_TAG" "rule_set" "$ruleset_tag")
+            ;;
         subnets) ;;
         *) log "Unsupported remote rule set type: $type" "warn" ;;
         esac
@@ -1011,7 +967,7 @@ configure_community_list_handler() {
 
     config=$(sing_box_cm_add_remote_ruleset "$config" "$ruleset_tag" "$format" "$url" "$detour" "$update_interval")
     config=$(sing_box_cm_patch_route_rule "$config" "$route_rule_tag" "rule_set" "$ruleset_tag")
-    _add_ruleset_to_dns_rules "$ruleset_tag"
+    config=$(sing_box_cm_patch_dns_route_rule "$config" "$SB_FAKEIP_DNS_RULE_TAG" "rule_set" "$ruleset_tag")
 }
 
 configure_user_domain_or_subnets_list() {
@@ -1070,7 +1026,7 @@ configure_local_domain_or_subnet_lists() {
     domains)
         config_list_foreach "$section" "local_domain_lists" import_local_domain_or_subnet_list "$type" \
             "$section" "$ruleset_filepath"
-        _add_ruleset_to_dns_rules "$ruleset_tag" "$route_rule_tag"
+        config=$(sing_box_cm_patch_dns_route_rule "$config" "$SB_FAKEIP_DNS_RULE_TAG" "rule_set" "$ruleset_tag")
         ;;
     subnets)
         config_list_foreach "$section" "local_subnet_lists" import_local_domain_or_subnet_list "$type" \
@@ -1130,7 +1086,9 @@ configure_remote_domain_or_subnet_list_handler() {
         config=$(sing_box_cm_add_remote_ruleset "$config" "$ruleset_tag" "$format" "$url" "$detour" "$update_interval")
         config=$(sing_box_cm_patch_route_rule "$config" "$route_rule_tag" "rule_set" "$ruleset_tag")
         case "$type" in
-        domains) _add_ruleset_to_dns_rules "$ruleset_tag" "$route_rule_tag" ;;
+        domains)
+            config=$(sing_box_cm_patch_dns_route_rule "$config" "$SB_FAKEIP_DNS_RULE_TAG" "rule_set" "$ruleset_tag")
+            ;;
         subnets) ;;
         *) log "Unsupported remote rule set type: $type" "warn" ;;
         esac
@@ -1139,17 +1097,6 @@ configure_remote_domain_or_subnet_list_handler() {
         log "Detected file extension: '$file_extension' → no processing needed, managed on list_update" "debug"
         ;;
     esac
-}
-
-_add_ruleset_to_dns_rules() {
-    local ruleset_tag="$1"
-
-    config=$(sing_box_cm_patch_dns_route_rule "$config" "$SB_FAKEIP_DNS_RULE_TAG" "rule_set" "$ruleset_tag")
-    local split_dns_enabled final_dns_server
-    config_get_bool split_dns_enabled "main" "split_dns_enabled" 0
-    if [ "$split_dns_enabled" -eq 1 ]; then
-        config=$(sing_box_cm_patch_dns_route_rule "$config" "$SB_INVERT_FAKEIP_DNS_RULE_TAG" "rule_set" "$ruleset_tag")
-    fi
 }
 
 sing_box_configure_experimental() {
@@ -1988,6 +1935,16 @@ check_dns_available() {
 print_global() {
     local message="$1"
     echo "$message"
+}
+
+find_working_resolver() {
+    for resolver in $DNS_RESOLVERS; do
+        if nslookup -timeout=2 "$FAKEIP_TEST_DOMAIN" "$resolver" > /dev/null 2>&1; then
+            echo "$resolver"
+            return 0
+        fi
+    done
+    return 1
 }
 
 global_check() {

--- a/podkop/files/usr/bin/podkop
+++ b/podkop/files/usr/bin/podkop
@@ -717,15 +717,32 @@ configure_outbound_handler() {
         ;;
     vpn)
         log "Configuring outbound in VPN connection mode for the $section section"
-        local interface_name
+        local interface_name domain_resolver_enabled domain_resolver_dns_type domain_resolver_dns_server \
+            outbound_tag domain_resolver_tag dns_domain_resolver
+
         config_get interface_name "$section" "interface"
+        config_get domain_resolver_enabled "$section" "domain_resolver_enabled"
+        config_get domain_resolver_dns_type "$section" "domain_resolver_dns_type"
+        config_get domain_resolver_dns_server "$section" "domain_resolver_dns_server"
 
         if [ -z "$interface_name" ]; then
             log "VPN interface is not set. Aborted." "fatal"
             exit 1
         fi
 
-        config=$(sing_box_cf_add_interface_outbound "$config" "$section" "$interface_name")
+        local outbound_tag
+        outbound_tag="$(get_outbound_tag_by_section "$section")"
+
+        if [ "$domain_resolver_enabled" -eq 1 ]; then
+            if ! is_ipv4 "$domain_resolver_dns_server"; then
+                dns_domain_resolver=$SB_BOOTSTRAP_SERVER_TAG
+            fi
+            domain_resolver_tag="$(get_domain_resolver_tag "$section")"
+            config=$(sing_box_cf_add_dns_server "$config" "$domain_resolver_dns_type" "$domain_resolver_tag" \
+                "$domain_resolver_dns_server" "$dns_domain_resolver" "$outbound_tag")
+        fi
+
+        config=$(sing_box_cm_add_interface_outbound "$config" "$outbound_tag" "$interface_name" "$domain_resolver_tag")
         ;;
     block)
         log "Connection mode 'block' detected for the $section section – no outbound will be created (handled via reject route rules)"
@@ -742,13 +759,12 @@ sing_box_configure_dns() {
     config=$(sing_box_cm_configure_dns "$config" "$SB_DNS_SERVER_TAG" "ipv4_only" true)
 
     log "Adding DNS Servers" "debug"
-    local dns_type dns_server bootstrap_dns_server dns_server_address dns_domain_resolver
+    local dns_type dns_server bootstrap_dns_server dns_domain_resolver
     config_get dns_type "main" "dns_type" "doh"
     config_get dns_server "main" "dns_server" "1.1.1.1"
     config_get bootstrap_dns_server "main" "bootstrap_dns_server" "77.88.8.8"
 
-    dns_server_address=$(url_get_host "$dns_server")
-    if ! is_ipv4 "$dns_server_address"; then
+    if ! is_ipv4 "$dns_server"; then
         dns_domain_resolver=$SB_BOOTSTRAP_SERVER_TAG
     fi
 

--- a/podkop/files/usr/lib/constants.sh
+++ b/podkop/files/usr/lib/constants.sh
@@ -25,10 +25,9 @@ SB_REQUIRED_VERSION="1.12.0"
 SB_DEFAULT_LOG_LEVEL="warn"
 # DNS
 SB_DNS_SERVER_TAG="dns-server"
-SB_SPLIT_DNS_SERVER_TAG="split-dns-server"
 SB_FAKEIP_DNS_SERVER_TAG="fakeip-server"
 SB_FAKEIP_INET4_RANGE="198.18.0.0/15"
-SB_DNS_DOMAIN_RESOLVER_TAG="dns-domain-resolver"
+SB_BOOTSTRAP_SERVER_TAG="bootstrap-dns-server"
 SB_FAKEIP_DNS_RULE_TAG="fakeip-dns-rule-tag"
 SB_INVERT_FAKEIP_DNS_RULE_TAG="invert-fakeip-dns-rule-tag"
 # Inbounds

--- a/podkop/files/usr/lib/helpers.sh
+++ b/podkop/files/usr/lib/helpers.sh
@@ -97,6 +97,14 @@ get_outbound_tag_by_section() {
     echo "$section-$postfix"
 }
 
+# Constructs and returns a domain resolver tag by appending a fixed postfix to the given section
+get_domain_resolver_tag() {
+    local section="$1"
+    local postfix="domain-resolver"
+
+    echo "$section-$postfix"
+}
+
 # Constructs and returns a ruleset tag using section, name, optional type, and a fixed postfix
 get_ruleset_tag() {
     local section="$1"

--- a/podkop/files/usr/lib/sing_box_config_manager.sh
+++ b/podkop/files/usr/lib/sing_box_config_manager.sh
@@ -788,6 +788,7 @@ sing_box_cm_set_vless_tls() {
 #   config: JSON configuration (string)
 #   tag: string, identifier for the outbound
 #   interface: string, network interface to bind the outbound
+#   domain_resolver: string, tag of the domain resolver to be used for this outbound (optional)
 # Outputs:
 #   Writes updated JSON configuration to stdout
 # Example:
@@ -797,15 +798,20 @@ sing_box_cm_add_interface_outbound() {
     local config="$1"
     local tag="$2"
     local interface="$3"
+    local domain_resolver="$4"
 
     echo "$config" | jq \
         --arg tag "$tag" \
         --arg interface "$interface" \
-        '.outbounds += [{
-            type: "direct",
-            tag: $tag,
-            bind_interface: $interface
-        }]'
+        --arg domain_resolver "$domain_resolver" \
+        '.outbounds += [
+            {
+                type: "direct",
+                tag: $tag,
+                bind_interface: $interface
+            }
+            + (if $domain_resolver != "" then {domain_resolver: $domain_resolver} else {} end)
+        ]'
 }
 
 #######################################


### PR DESCRIPTION
# Описание изменений

1) Удаленён неработающий Split DNS
2) Добавлен Bootstrap DNS Server для резолвинга адресов DNS серверов
3) Split DNS заменен на domain_resolver direct аутбаундов VPN интерфейсов