### PR TITLE
fix:remove stray character causing error

### DIFF
--- a/podkop/files/usr/bin/podkop
+++ b/podkop/files/usr/bin/podkop
@@ -1671,7 +1671,7 @@ check_logs() {
         nolog "Logs not found"
         return 1
     fi
-    ы
+
     # Find the last occurrence of "Starting podkop"
     local start_line
     start_line=$(echo "$logs" | grep -n "podkop.*Starting podkop" | tail -n 1 | cut -d: -f1)


### PR DESCRIPTION
# Описание изменений

Fix error in the check_logs():
/usr/bin/podkop: line 1629: ы: not found 
