### PR TITLE
Fix/service listen address

### DIFF
--- a/podkop/files/usr/bin/podkop
+++ b/podkop/files/usr/bin/podkop
@@ -1512,7 +1512,7 @@ get_service_listen_address() {
         return 0
     fi
 
-    service_listen_address="$(uci_get "network" "lan" "ipaddr")"
+    service_listen_address="$(uci_get "network" "lan" "ipaddr" | awk '{print $1}' | cut -d'/' -f1)"
 
     if [ -z "$service_listen_address" ]; then
         log "Failed to determine the listening IP address. Please open an issue to report this problem: https://github.com/itdoginfo/podkop/issues" "error"


### PR DESCRIPTION
# Описание изменений

Исправление определения прослушиваемого IP адреса в случае включенного CIDR list notation в настройках LAN интерфейса

## Что изменено

- Опция service_listen_address в settings теперь полностью переопределяет автоматическое определение, даже если адрес был успешно получен
- uci get выбирает из network.lan.ipaddr только первый IP адрес без маски подсети