### PR TITLE
usr/bin/podkop заменить все 0x105 на 0x01000000 (или любой другой) чтобы не пересекаться с mwan3

### DIFF
--- a/podkop/files/usr/bin/podkop
+++ b/podkop/files/usr/bin/podkop
@@ -163,7 +163,7 @@ stop_main() {
 
     log "Flush ip rule"
     if ip rule list | grep -q "podkop"; then
-        ip rule del fwmark 0x105 table podkop priority 105
+        ip rule del fwmark 0x01000000/0xFF000000 table $table priority 105
     fi
 
     log "Flush ip route"
@@ -261,9 +261,9 @@ route_table_rule_mark() {
         log "Route for tproxy exists" "debug"
     fi
 
-    if ! ip rule list | grep -q "from all fwmark 0x105 lookup $table"; then
+    if ! ip rule list | grep -q "from all fwmark 0x01000000 lookup $table"; then
         log "Create marking rule" "debug"
-        ip -4 rule add fwmark 0x105 table $table priority 105
+        ip -4 rule add fwmark 0x01000000/0xFF000000 table $table priority 105
     else
         log "Marking rule exist" "debug"
     fi
@@ -313,19 +313,19 @@ create_nft_rules() {
     nft add chain inet "$NFT_TABLE_NAME" mangle_output '{ type route hook output priority -150; policy accept; }'
     nft add chain inet "$NFT_TABLE_NAME" proxy '{ type filter hook prerouting priority -100; policy accept; }'
 
-    nft add rule inet "$NFT_TABLE_NAME" mangle iifname "@$NFT_INTERFACE_SET_NAME" ip daddr "@$NFT_COMMON_SET_NAME" meta l4proto tcp meta mark set 0x105 counter
-    nft add rule inet "$NFT_TABLE_NAME" mangle iifname "@$NFT_INTERFACE_SET_NAME" ip daddr "@$NFT_COMMON_SET_NAME" meta l4proto udp meta mark set 0x105 counter
-    nft add rule inet "$NFT_TABLE_NAME" mangle iifname "@$NFT_INTERFACE_SET_NAME" ip daddr "$SB_FAKEIP_INET4_RANGE" meta l4proto tcp meta mark set 0x105 counter
-    nft add rule inet "$NFT_TABLE_NAME" mangle iifname "@$NFT_INTERFACE_SET_NAME" ip daddr "$SB_FAKEIP_INET4_RANGE" meta l4proto udp meta mark set 0x105 counter
+    nft add rule inet "$NFT_TABLE_NAME" mangle iifname "@$NFT_INTERFACE_SET_NAME" ip daddr "@$NFT_COMMON_SET_NAME" meta l4proto tcp meta mark set 0x01000000 counter
+    nft add rule inet "$NFT_TABLE_NAME" mangle iifname "@$NFT_INTERFACE_SET_NAME" ip daddr "@$NFT_COMMON_SET_NAME" meta l4proto udp meta mark set 0x01000000 counter
+    nft add rule inet "$NFT_TABLE_NAME" mangle iifname "@$NFT_INTERFACE_SET_NAME" ip daddr "$SB_FAKEIP_INET4_RANGE" meta l4proto tcp meta mark set 0x01000000 counter
+    nft add rule inet "$NFT_TABLE_NAME" mangle iifname "@$NFT_INTERFACE_SET_NAME" ip daddr "$SB_FAKEIP_INET4_RANGE" meta l4proto udp meta mark set 0x01000000 counter
 
-    nft add rule inet "$NFT_TABLE_NAME" proxy meta mark 0x105 meta l4proto tcp tproxy ip to 127.0.0.1:1602 counter
-    nft add rule inet "$NFT_TABLE_NAME" proxy meta mark 0x105 meta l4proto udp tproxy ip to 127.0.0.1:1602 counter
+    nft add rule inet "$NFT_TABLE_NAME" proxy meta mark \& 0xFF000000 == 0x01000000 meta l4proto tcp tproxy ip to 127.0.0.1:1602 counter
+    nft add rule inet "$NFT_TABLE_NAME" proxy meta mark \& 0xFF000000 == 0x01000000 meta l4proto udp tproxy ip to 127.0.0.1:1602 counter
 
     nft add rule inet "$NFT_TABLE_NAME" mangle_output ip daddr "@$NFT_LOCALV4_SET_NAME" return
-    nft add rule inet "$NFT_TABLE_NAME" mangle_output ip daddr "@$NFT_COMMON_SET_NAME" meta l4proto tcp meta mark set 0x105 counter
-    nft add rule inet "$NFT_TABLE_NAME" mangle_output ip daddr "@$NFT_COMMON_SET_NAME" meta l4proto udp meta mark set 0x105 counter
-    nft add rule inet "$NFT_TABLE_NAME" mangle_output ip daddr "$SB_FAKEIP_INET4_RANGE" meta l4proto tcp meta mark set 0x105 counter
-    nft add rule inet "$NFT_TABLE_NAME" mangle_output ip daddr "$SB_FAKEIP_INET4_RANGE" meta l4proto udp meta mark set 0x105 counter
+    nft add rule inet "$NFT_TABLE_NAME" mangle_output ip daddr "@$NFT_COMMON_SET_NAME" meta l4proto tcp meta mark set 0x01000000 counter
+    nft add rule inet "$NFT_TABLE_NAME" mangle_output ip daddr "@$NFT_COMMON_SET_NAME" meta l4proto udp meta mark set 0x01000000 counter
+    nft add rule inet "$NFT_TABLE_NAME" mangle_output ip daddr "$SB_FAKEIP_INET4_RANGE" meta l4proto tcp meta mark set 0x01000000 counter
+    nft add rule inet "$NFT_TABLE_NAME" mangle_output ip daddr "$SB_FAKEIP_INET4_RANGE" meta l4proto udp meta mark set 0x01000000 counter
 
     local exclude_ntp
     config_get_bool exclude_ntp "settings" "exclude_ntp" "0"
@@ -1243,7 +1243,7 @@ import_community_service_subnet_list_handler() {
         URL=$SUBNETS_DISCORD
         nft_create_ipv4_set "$NFT_TABLE_NAME" "$NFT_DISCORD_SET_NAME"
         nft add rule inet "$NFT_TABLE_NAME" mangle iifname "@$NFT_INTERFACE_SET_NAME" ip daddr \
-            "@$NFT_DISCORD_SET_NAME" udp dport '{ 50000-65535 }' meta mark set 0x105 counter
+            "@$NFT_DISCORD_SET_NAME" udp dport '{ 50000-65535 }' meta mark set 0x01000000 counter
         ;;
     *) return 0 ;;
     esac
@@ -1532,8 +1532,8 @@ nft_list_all_traffic_from_ip() {
     local ip="$1"
 
     if ! nft list chain inet "$NFT_TABLE_NAME" mangle | grep -q "ip saddr $ip"; then
-        nft insert rule inet "$NFT_TABLE_NAME" mangle iifname "@$NFT_INTERFACE_SET_NAME" ip saddr "$ip" meta l4proto tcp meta mark set 0x105 counter
-        nft insert rule inet "$NFT_TABLE_NAME" mangle iifname "@$NFT_INTERFACE_SET_NAME" ip saddr "$ip" meta l4proto udp meta mark set 0x105 counter
+        nft insert rule inet "$NFT_TABLE_NAME" mangle iifname "@$NFT_INTERFACE_SET_NAME" ip saddr "$ip" meta l4proto tcp meta mark set 0x01000000 counter
+        nft insert rule inet "$NFT_TABLE_NAME" mangle iifname "@$NFT_INTERFACE_SET_NAME" ip saddr "$ip" meta l4proto udp meta mark set 0x01000000 counter
         nft insert rule inet "$NFT_TABLE_NAME" mangle ip saddr "$ip" ip daddr @localv4 return
     fi
 }


### PR DESCRIPTION
usr/bin/podkop и заменить все 0x105 на 0x01000000 (или любой другой) чтобы не пересекаться с mwan3
Есть открытый баг с пересечением fwmark ,если использовать podkop и балансировщик mwan3 на одном роутере, с несколькими wan
💡 Предлагаемое решение
usr/bin/podkop и заменить все 0x105 на 0x01000000 (или любой другой) чтобы не пересекаться с mwan3
далее в скрипте выборочно меняем строки к такому виду
ip -4 rule add fwmark 0x01000000/0xFF000000 table $table priority 105
ip rule del fwmark 0x01000000/0xFF000000 table $table priority 105 # если есть del
Tproxy — Тут важно именно заменить на "\\& 0xFF000000 == 0x01000000"
nft add rule inet "$NFT_TABLE_NAME" proxy meta mark \\& 0xFF000000 == 0x01000000 meta l4proto tcp tproxy ip to 127.0.0.1:1602 counter
nft add rule inet "$NFT_TABLE_NAME" proxy meta mark \\& 0xFF000000 == 0x01000000 meta l4proto udp tproxy ip to 127.0.0.1:1602 counter
сохраняем рестартим podkop
на выходе проверка
root@OpenWrt: nft list table inet PodkopTable | grep proxy
chain proxy {
meta mark & 0xff000000 == 0x01000000 meta l4proto tcp tproxy ip to 127.0.0.1:1602 counter packets 686 bytes 456647
meta mark & 0xff000000 == 0x01000000 meta l4proto udp tproxy ip to 127.0.0.1:1602 counter packets 51 bytes 75296
root@OpenWrt: ip rule show | grep podkop
105: from all fwmark 0x1000000/0xff000000 lookup podkop
root@OpenWrt: И диагностика вся проходит без ошибок , и балансировщик в паре с подкопом работают как часики , тем самым мы закрыли баг