### PR TITLE
Чистка логов и конфига от escape кодов

### DIFF
--- a/podkop/files/usr/bin/podkop
+++ b/podkop/files/usr/bin/podkop
@@ -1765,7 +1765,7 @@ check_logs() {
     fi
 
     local logs
-    logs=$(logread | grep -E "podkop|sing-box")
+    logs=$(logread | grep -E "podkop|sing-box" | sed 's/\x1b\[[0-9;]*m//g')
 
     if [ -z "$logs" ]; then
         nolog "Logs not found"


### PR DESCRIPTION
## Что изменено

Исправляет https://github.com/itdoginfo/podkop/issues/243 5-6
- Строка лишняя, в показе sing-box конфига, при копировании и скачивании приходится удалять
- Почищены логи от escape-кодов, чтобы улучшилась читабельность.