### PR TITLE
fix(shell): защита optional hysteria2 network arg при nounset

### DIFF
--- a/podkop/files/usr/lib/sing_box_config_manager.sh
+++ b/podkop/files/usr/lib/sing_box_config_manager.sh
@@ -690,7 +690,7 @@ sing_box_cm_add_hysteria2_outbound() {
     local obfuscator_password="$7"
     local upload_mbps="$8"
     local download_mbps="$9"
-    local network="${10}"
+    local network="${10:-}"
 
     echo "$config" | jq \
         --arg tag "$tag" \


### PR DESCRIPTION
## Что изменено
- исправлен parsing optional аргумента `hysteria2` outbound при `set -u`
- замена `local network="${10}"` на `local network="${10:-}"`

## Почему
При `set -u` обращение к unset positional parameter вызывает `unbound variable` error.
Для этого parser path параметр `network` optional, поэтому отсутствие аргумента не должно ломать config generation.

## Scope
- one-line shell fix
- файл: `podkop/files/usr/lib/sing_box_config_manager.sh`

## Влияние на поведение
- без изменений, когда arg 10 передан
- предотвращает failure, когда arg 10 отсутствует
