### PR TITLE
Update sing_box_config_manager.sh fix dns hijack

### DIFF
--- a/podkop/files/usr/lib/sing_box_config_manager.sh
+++ b/podkop/files/usr/lib/sing_box_config_manager.sh
@@ -1178,7 +1178,7 @@ sing_box_cm_add_hijack_dns_route_rule() {
         --arg key "$key" \
         --argjson value "$value" \
         '.route.rules += [{
-            action: "hijack-dns",
+            action: "hijack-dns", inbound: "dns-in",
             ($key): $value
         }]'
 }


### PR DESCRIPTION
Исправил проблему совместного использования с dnsmasq
схема  подключения:
client->dnsmasq->sing-box (127.0.0.42)->dnsproxy(127.0.0.55)->DoT

При большой нагрузке sing-box открывает множество прослушиваний на udp 53 из-за этого dnsmasq перестает отвечать на запросы. Хорошо проявляется, если добавить много подсетей podkop_subnets 
пример указан в конце

# Описание изменений

При генерации конфига singbox в секцию "hijack-dns" добавил принудительно использовать только входящий интерфейс

 inbound: "dns-in"




## Что изменено
Fixed a conflict with dnsmasq caused by multiple listeners on UDP port 53.

root@Vostok2:~# netstat -lnup 2>/dev/null | grep ':53 '
udp        0      0 10.100.100.1:53        0.0.0.0:*                           26136/sing-box
udp     4352      0 10.100.100.1:53        0.0.0.0:*                           26136/sing-box
udp    13056      0 10.100.100.1:53        0.0.0.0:*                           26136/sing-box
udp    13056      0 10.100.100.1:53        0.0.0.0:*                           26136/sing-box
udp     4352      0 10.100.100.1:53        0.0.0.0:*                           26136/sing-box
udp    15616      0 10.100.100.1:53        0.0.0.0:*                           26136/sing-box
udp        0      0 10.100.100.1:53        0.0.0.0:*                           26136/sing-box
udp   131584      0 10.100.100.1:53        0.0.0.0:*                           26136/sing-box
udp   160000      0 10.100.100.1:53        0.0.0.0:*                           26136/sing-box
udp    96512      0 10.100.100.1:53        0.0.0.0:*                           26136/sing-box
udp   110080      0 10.100.100.1:53        0.0.0.0:*                           26136/sing-box
udp    96512      0 10.100.100.1:53        0.0.0.0:*                           26136/sing-box
udp    63744      0 10.100.100.1:53        0.0.0.0:*                           26136/sing-box
udp   104448      0 10.100.100.1:53        0.0.0.0:*                           26136/sing-box
udp    62464      0 10.100.100.1:53        0.0.0.0:*                           26136/sing-box
udp   101376      0 10.100.100.1:53        0.0.0.0:*                           26136/sing-box
udp   101632      0 10.100.100.1:53        0.0.0.0:*                           26136/sing-box
udp        0      0 127.0.0.42:53           0.0.0.0:*                           26136/sing-box
udp        0      0 127.0.0.1:53            0.0.0.0:*                           16711/dnsmasq
udp        0      0 10.100.100.1:53        0.0.0.0:*                           16711/dnsmasq
udp        0      0 10.0.0.1:53             0.0.0.0:*                           16711/dnsmasq
udp        0      0 192.168.10.1:53         0.0.0.0:*                           16711/dnsmasq
udp        0      0 10.0.10.1:53            0.0.0.0:*                           16711/dnsmasq
udp        0      0 10.0.20.1:53            0.0.0.0:*                           16711/dnsmasq
udp        0      0 127.0.0.55:53           0.0.0.0:*                           5062/dnsproxy
udp        0      0 ::1:53                  :::*                                16711/dnsmasq
udp        0      0 fc00::10:0:0:1:53       :::*                                16711/dnsmasq
udp        0      0 fe80::4071:daff:fe53:ef81:53 :::*                                16711/dnsmasq
udp        0      0 fe80::df25:6eec:d2c3:1a22:53 :::*                                16711/dnsmasq
udp        0      0 fe80::430b:9d7:18a7:1536:53 :::*                                16711/dnsmasq