### PR TITLE
fix: skip fakeip dns rules for exclusion domains

### DIFF
--- a/podkop/files/usr/bin/podkop
+++ b/podkop/files/usr/bin/podkop
@@ -998,7 +998,9 @@ configure_community_list_handler() {
 
     config=$(sing_box_cm_add_remote_ruleset "$config" "$ruleset_tag" "$format" "$url" "$detour" "$update_interval")
     config=$(sing_box_cm_patch_route_rule "$config" "$route_rule_tag" "rule_set" "$ruleset_tag")
-    config=$(sing_box_cm_patch_dns_route_rule "$config" "$SB_FAKEIP_DNS_RULE_TAG" "rule_set" "$ruleset_tag")
+    if [ "$route_rule_tag" != "$SB_EXCLUSION_RULE_TAG" ]; then
+        config=$(sing_box_cm_patch_dns_route_rule "$config" "$SB_FAKEIP_DNS_RULE_TAG" "rule_set" "$ruleset_tag")
+    fi
 }
 
 prepare_source_ruleset() {
@@ -1017,7 +1019,9 @@ prepare_source_ruleset() {
         config=$(sing_box_cm_patch_route_rule "$config" "$route_rule_tag" "rule_set" "$ruleset_tag")
         case "$type" in
         domains)
-            config=$(sing_box_cm_patch_dns_route_rule "$config" "$SB_FAKEIP_DNS_RULE_TAG" "rule_set" "$ruleset_tag")
+            if [ "$route_rule_tag" != "$SB_EXCLUSION_RULE_TAG" ]; then
+                config=$(sing_box_cm_patch_dns_route_rule "$config" "$SB_FAKEIP_DNS_RULE_TAG" "rule_set" "$ruleset_tag")
+            fi
             ;;
         subnets) ;;
         *)
@@ -1133,7 +1137,9 @@ configure_remote_domain_or_subnet_list_handler() {
         config=$(sing_box_cm_patch_route_rule "$config" "$route_rule_tag" "rule_set" "$ruleset_tag")
         case "$type" in
         domains)
-            config=$(sing_box_cm_patch_dns_route_rule "$config" "$SB_FAKEIP_DNS_RULE_TAG" "rule_set" "$ruleset_tag")
+            if [ "$route_rule_tag" != "$SB_EXCLUSION_RULE_TAG" ]; then
+                config=$(sing_box_cm_patch_dns_route_rule "$config" "$SB_FAKEIP_DNS_RULE_TAG" "rule_set" "$ruleset_tag")
+            fi
             ;;
         subnets) ;;
         *) log "Unsupported remote rule set type: $type" "error" ;;


### PR DESCRIPTION
Fixes #350

Domains in the Exclusion section were resolved through FakeIP (198.18.x.x) instead of real DNS, causing excluded traffic to be routed via the proxy.

Wrap each `sing_box_cm_patch_dns_route_rule` call that targets `SB_FAKEIP_DNS_RULE_TAG` with a guard skipping rule sets whose `route_rule_tag` equals `SB_EXCLUSION_RULE_TAG`.

Three call sites in `podkop/files/usr/bin/podkop`:
- `configure_community_list_handler`
- `prepare_source_ruleset`
- `configure_remote_domain_or_subnet_list_handler`

## Test plan
- [ ] Create an Exclusion section with any domain
- [ ] Run `nslookup <domain> 127.0.0.42`
- [ ] Verify response is a real IP, not from `198.18.x.x`