### PR TITLE
Add func to insert resolve action in route.rules section

### DIFF
--- a/fe-app-podkop/locales/calls.json
+++ b/fe-app-podkop/locales/calls.json
@@ -52,21 +52,21 @@
     "call": "Applicable for SOCKS and Shadowsocks proxy",
     "key": "Applicable for SOCKS and Shadowsocks proxy",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:198"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:199"
     ]
   },
   {
     "call": "At least one valid domain must be specified. Comments-only content is not allowed.",
     "key": "At least one valid domain must be specified. Comments-only content is not allowed.",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:443"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:444"
     ]
   },
   {
     "call": "At least one valid subnet or IP must be specified. Comments-only content is not allowed.",
     "key": "At least one valid subnet or IP must be specified. Comments-only content is not allowed.",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:524"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:525"
     ]
   },
   {
@@ -178,7 +178,7 @@
     "call": "Community Lists",
     "key": "Community Lists",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:298"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:299"
     ]
   },
   {
@@ -199,7 +199,7 @@
     "call": "Configuration Type",
     "key": "Configuration Type",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:22"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:23"
     ]
   },
   {
@@ -213,7 +213,7 @@
     "call": "Connection URL",
     "key": "Connection URL",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:25"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:26"
     ]
   },
   {
@@ -297,8 +297,8 @@
     "call": "Disabled",
     "key": "Disabled",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:389",
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:469"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:390",
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:470"
     ]
   },
   {
@@ -312,7 +312,7 @@
     "call": "DNS over HTTPS (DoH)",
     "key": "DNS over HTTPS (DoH)",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:266",
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:267",
       "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:15"
     ]
   },
@@ -320,7 +320,7 @@
     "call": "DNS over TLS (DoT)",
     "key": "DNS over TLS (DoT)",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:267",
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:268",
       "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:16"
     ]
   },
@@ -328,7 +328,7 @@
     "call": "DNS Protocol Type",
     "key": "DNS Protocol Type",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:263",
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:264",
       "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:12"
     ]
   },
@@ -343,7 +343,7 @@
     "call": "DNS Server",
     "key": "DNS Server",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:276",
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:277",
       "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:24"
     ]
   },
@@ -365,7 +365,7 @@
     "call": "Domain Resolver",
     "key": "Domain Resolver",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:253"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:254"
     ]
   },
   {
@@ -416,8 +416,8 @@
     "call": "Dynamic List",
     "key": "Dynamic List",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:390",
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:470"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:391",
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:471"
     ]
   },
   {
@@ -431,14 +431,21 @@
     "call": "Enable built-in DNS resolver for domains handled by this section",
     "key": "Enable built-in DNS resolver for domains handled by this section",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:254"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:255"
+    ]
+  },
+  {
+    "call": "Enable DNS resolve to get real IP when routing",
+    "key": "Enable DNS resolve to get real IP when routing",
+    "places": [
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:691"
     ]
   },
   {
     "call": "Enable Mixed Proxy",
     "key": "Enable Mixed Proxy",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:662"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:665"
     ]
   },
   {
@@ -452,7 +459,7 @@
     "call": "Enable the mixed proxy, allowing this section to route traffic through both HTTP and SOCKS proxies",
     "key": "Enable the mixed proxy, allowing this section to route traffic through both HTTP and SOCKS proxies",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:663"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:666"
     ]
   },
   {
@@ -473,56 +480,56 @@
     "call": "Enter complete outbound configuration in JSON format",
     "key": "Enter complete outbound configuration in JSON format",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:65"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:66"
     ]
   },
   {
     "call": "Enter domain names separated by commas, spaces, or newlines. You can add comments using //",
     "key": "Enter domain names separated by commas, spaces, or newlines. You can add comments using //",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:425"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:426"
     ]
   },
   {
     "call": "Enter domain names without protocols, e.g. example.com or sub.example.com",
     "key": "Enter domain names without protocols, e.g. example.com or sub.example.com",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:399"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:400"
     ]
   },
   {
     "call": "Enter subnets in CIDR notation (e.g. 103.21.244.0/22) or single IP addresses",
     "key": "Enter subnets in CIDR notation (e.g. 103.21.244.0/22) or single IP addresses",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:479"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:480"
     ]
   },
   {
     "call": "Every 1 minute",
     "key": "Every 1 minute",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:137"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:138"
     ]
   },
   {
     "call": "Every 3 minutes",
     "key": "Every 3 minutes",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:138"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:139"
     ]
   },
   {
     "call": "Every 30 seconds",
     "key": "Every 30 seconds",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:136"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:137"
     ]
   },
   {
     "call": "Every 5 minutes",
     "key": "Every 5 minutes",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:139"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:140"
     ]
   },
   {
@@ -554,15 +561,15 @@
       "src/podkop/tabs/diagnostic/initController.ts:231",
       "src/podkop/tabs/diagnostic/initController.ts:261",
       "src/podkop/tabs/diagnostic/initController.ts:265",
-      "src/podkop/tabs/diagnostic/initController.ts:299",
-      "src/podkop/tabs/diagnostic/initController.ts:303"
+      "src/podkop/tabs/diagnostic/initController.ts:302",
+      "src/podkop/tabs/diagnostic/initController.ts:306"
     ]
   },
   {
     "call": "Fastest",
     "key": "Fastest",
     "places": [
-      "src/podkop/methods/custom/getDashboardSections.ts:117",
+      "src/podkop/methods/custom/getDashboardSections.ts:148",
       "src/podkop/tabs/diagnostic/checks/runSectionsCheck.ts:59"
     ]
   },
@@ -570,7 +577,7 @@
     "call": "Fully Routed IPs",
     "key": "Fully Routed IPs",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:637"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:638"
     ]
   },
   {
@@ -936,7 +943,7 @@
     "call": "Latest",
     "key": "Latest",
     "places": [
-      "src/podkop/tabs/diagnostic/initController.ts:453"
+      "src/podkop/tabs/diagnostic/initController.ts:456"
     ]
   },
   {
@@ -950,14 +957,14 @@
     "call": "Local Domain Lists",
     "key": "Local Domain Lists",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:545"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:546"
     ]
   },
   {
     "call": "Local Subnet Lists",
     "key": "Local Subnet Lists",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:568"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:569"
     ]
   },
   {
@@ -985,7 +992,7 @@
     "call": "Mixed Proxy Port",
     "key": "Mixed Proxy Port",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:673"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:678"
     ]
   },
   {
@@ -999,14 +1006,14 @@
     "call": "Must be a number in the range of 50 - 1000",
     "key": "Must be a number in the range of 50 - 1000",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:163"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:164"
     ]
   },
   {
     "call": "Network Interface",
     "key": "Network Interface",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:207"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:208"
     ]
   },
   {
@@ -1054,21 +1061,21 @@
     "call": "Outbound Config",
     "key": "Outbound Config",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:28"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:29"
     ]
   },
   {
     "call": "Outbound Configuration",
     "key": "Outbound Configuration",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:64"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:65"
     ]
   },
   {
     "call": "Outdated",
     "key": "Outdated",
     "places": [
-      "src/podkop/tabs/diagnostic/initController.ts:443"
+      "src/podkop/tabs/diagnostic/initController.ts:446"
     ]
   },
   {
@@ -1142,7 +1149,7 @@
     "call": "Proxy Configuration URL",
     "key": "Proxy Configuration URL",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:35"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:36"
     ]
   },
   {
@@ -1163,21 +1170,28 @@
     "call": "Regional options cannot be used together",
     "key": "Regional options cannot be used together",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:332"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:333"
     ]
   },
   {
     "call": "Remote Domain Lists",
     "key": "Remote Domain Lists",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:591"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:592"
     ]
   },
   {
     "call": "Remote Subnet Lists",
     "key": "Remote Subnet Lists",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:614"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:615"
+    ]
+  },
+  {
+    "call": "Resolve real IP for routing",
+    "key": "Resolve real IP for routing",
+    "places": [
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:690"
     ]
   },
   {
@@ -1261,7 +1275,7 @@
     "call": "Russia inside restrictions",
     "key": "Russia inside restrictions",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:351"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:352"
     ]
   },
   {
@@ -1282,7 +1296,7 @@
     "call": "Select a predefined list for routing",
     "key": "Select a predefined list for routing",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:299"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:300"
     ]
   },
   {
@@ -1310,21 +1324,21 @@
     "call": "Select how to configure the proxy",
     "key": "Select how to configure the proxy",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:23"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:24"
     ]
   },
   {
     "call": "Select network interface for VPN connection",
     "key": "Select network interface for VPN connection",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:208"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:209"
     ]
   },
   {
     "call": "Select or enter DNS server address",
     "key": "Select or enter DNS server address",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:277",
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:278",
       "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:25"
     ]
   },
@@ -1346,21 +1360,21 @@
     "call": "Select the DNS protocol type for the domain resolver",
     "key": "Select the DNS protocol type for the domain resolver",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:264"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:265"
     ]
   },
   {
     "call": "Select the list type for adding custom domains",
     "key": "Select the list type for adding custom domains",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:387"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:388"
     ]
   },
   {
     "call": "Select the list type for adding custom subnets",
     "key": "Select the list type for adding custom subnets",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:467"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:468"
     ]
   },
   {
@@ -1395,14 +1409,14 @@
     "call": "Selector",
     "key": "Selector",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:26"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:27"
     ]
   },
   {
     "call": "Selector Proxy Links",
     "key": "Selector Proxy Links",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:87"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:88"
     ]
   },
   {
@@ -1494,29 +1508,29 @@
     "call": "Specify local IP addresses or subnets whose traffic will always be routed through the configured route",
     "key": "Specify local IP addresses or subnets whose traffic will always be routed through the configured route",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:638"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:639"
     ]
   },
   {
     "call": "Specify remote URLs to download and use domain lists",
     "key": "Specify remote URLs to download and use domain lists",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:592"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:593"
     ]
   },
   {
     "call": "Specify remote URLs to download and use subnet lists",
     "key": "Specify remote URLs to download and use subnet lists",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:615"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:616"
     ]
   },
   {
     "call": "Specify the path to the list file located on the router filesystem",
     "key": "Specify the path to the list file located on the router filesystem",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:546",
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:569"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:547",
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:570"
     ]
   },
   {
@@ -1572,8 +1586,8 @@
     "call": "Text List",
     "key": "Text List",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:391",
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:471"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:392",
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:472"
     ]
   },
   {
@@ -1587,21 +1601,21 @@
     "call": "The interval between connectivity tests",
     "key": "The interval between connectivity tests",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:134"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:135"
     ]
   },
   {
     "call": "The maximum difference in response times (ms) allowed when comparing servers",
     "key": "The maximum difference in response times (ms) allowed when comparing servers",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:147"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:148"
     ]
   },
   {
     "call": "The URL used to test server connectivity",
     "key": "The URL used to test server connectivity",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:170"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:171"
     ]
   },
   {
@@ -1650,7 +1664,7 @@
     "call": "UDP (Unprotected DNS)",
     "key": "UDP (Unprotected DNS)",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:268",
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:269",
       "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:17"
     ]
   },
@@ -1658,7 +1672,7 @@
     "call": "UDP over TCP",
     "key": "UDP over TCP",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:197"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:198"
     ]
   },
   {
@@ -1671,7 +1685,7 @@
       "src/podkop/tabs/diagnostic/initController.ts:41",
       "src/podkop/tabs/diagnostic/initController.ts:42",
       "src/podkop/tabs/diagnostic/initController.ts:43",
-      "src/podkop/tabs/diagnostic/initController.ts:417"
+      "src/podkop/tabs/diagnostic/initController.ts:420"
     ]
   },
   {
@@ -1707,77 +1721,77 @@
     "call": "URLTest",
     "key": "URLTest",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:27"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:28"
     ]
   },
   {
     "call": "URLTest Check Interval",
     "key": "URLTest Check Interval",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:133"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:134"
     ]
   },
   {
     "call": "URLTest Proxy Links",
     "key": "URLTest Proxy Links",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:110"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:111"
     ]
   },
   {
     "call": "URLTest Testing URL",
     "key": "URLTest Testing URL",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:169"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:170"
     ]
   },
   {
     "call": "URLTest Tolerance",
     "key": "URLTest Tolerance",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:146"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:147"
     ]
   },
   {
     "call": "User Domain List Type",
     "key": "User Domain List Type",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:386"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:387"
     ]
   },
   {
     "call": "User Domains",
     "key": "User Domains",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:398"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:399"
     ]
   },
   {
     "call": "User Domains List",
     "key": "User Domains List",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:424"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:425"
     ]
   },
   {
     "call": "User Subnet List Type",
     "key": "User Subnet List Type",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:466"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:467"
     ]
   },
   {
     "call": "User Subnets",
     "key": "User Subnets",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:478"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:479"
     ]
   },
   {
     "call": "User Subnets List",
     "key": "User Subnets List",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:504"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:505"
     ]
   },
   {
@@ -1804,8 +1818,8 @@
     "call": "Validation errors:",
     "key": "Validation errors:",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:457",
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:536"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:458",
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:537"
     ]
   },
   {
@@ -1827,23 +1841,23 @@
     "call": "vless://, ss://, trojan://, socks4/5://, hy2/hysteria2:// links",
     "key": "vless://, ss://, trojan://, socks4/5://, hy2/hysteria2:// links",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:36",
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:88",
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:111"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:37",
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:89",
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:112"
     ]
   },
   {
     "call": "Warning: %s cannot be used together with %s. Previous selections have been removed.",
     "key": "Warning: %s cannot be used together with %s. Previous selections have been removed.",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:334"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:335"
     ]
   },
   {
     "call": "Warning: Russia inside can only be used with %s. %s already in Russia inside and have been removed from selection.",
     "key": "Warning: Russia inside can only be used with %s. %s already in Russia inside and have been removed from selection.",
     "places": [
-      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:353"
+      "../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:354"
     ]
   },
   {

--- a/fe-app-podkop/locales/podkop.pot
+++ b/fe-app-podkop/locales/podkop.pot
@@ -1,15 +1,15 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2026 THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PODKOP package.
-# divocatt <210179590+divocatt@users.noreply.github.com>, 2026.
+# romanvht <romanvht@gmail.com>, 2026.
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PODKOP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-14 18:21+0200\n"
-"PO-Revision-Date: 2026-01-14 18:21+0200\n"
-"Last-Translator: divocatt <210179590+divocatt@users.noreply.github.com>\n"
+"POT-Creation-Date: 2026-05-09 02:49+1000\n"
+"PO-Revision-Date: 2026-05-09 02:49+1000\n"
+"Last-Translator: romanvht <romanvht@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -44,15 +44,15 @@ msgstr ""
 msgid "Allows access to YACD from the WAN. Make sure to open the appropriate port in your firewall."
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:198
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:199
 msgid "Applicable for SOCKS and Shadowsocks proxy"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:443
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:444
 msgid "At least one valid domain must be specified. Comments-only content is not allowed."
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:524
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:525
 msgid "At least one valid subnet or IP must be specified. Comments-only content is not allowed."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:298
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:299
 msgid "Community Lists"
 msgstr ""
 
@@ -131,7 +131,7 @@ msgstr ""
 msgid "Configuration for Podkop service"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:22
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:23
 msgid "Configuration Type"
 msgstr ""
 
@@ -139,7 +139,7 @@ msgstr ""
 msgid "Connection Type"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:25
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:26
 msgid "Connection URL"
 msgstr ""
 
@@ -187,8 +187,8 @@ msgstr ""
 msgid "Disable the QUIC protocol to improve compatibility or fix issues with video streaming"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:389
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:469
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:390
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:470
 msgid "Disabled"
 msgstr ""
 
@@ -196,17 +196,17 @@ msgstr ""
 msgid "DNS on router"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:266
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:267
 #: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:15
 msgid "DNS over HTTPS (DoH)"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:267
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:268
 #: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:16
 msgid "DNS over TLS (DoT)"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:263
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:264
 #: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:12
 msgid "DNS Protocol Type"
 msgstr ""
@@ -215,7 +215,7 @@ msgstr ""
 msgid "DNS Rewrite TTL"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:276
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:277
 #: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:24
 msgid "DNS Server"
 msgstr ""
@@ -228,7 +228,7 @@ msgstr ""
 msgid "Do not panic, everything can be fixed, just..."
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:253
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:254
 msgid "Domain Resolver"
 msgstr ""
 
@@ -258,8 +258,8 @@ msgstr ""
 msgid "Downloading all lists via specific Proxy/VPN"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:390
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:470
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:391
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:471
 msgid "Dynamic List"
 msgstr ""
 
@@ -267,11 +267,15 @@ msgstr ""
 msgid "Enable autostart"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:254
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:255
 msgid "Enable built-in DNS resolver for domains handled by this section"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:662
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:691
+msgid "Enable DNS resolve to get real IP when routing"
+msgstr ""
+
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:665
 msgid "Enable Mixed Proxy"
 msgstr ""
 
@@ -279,7 +283,7 @@ msgstr ""
 msgid "Enable Output Network Interface"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:663
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:666
 msgid "Enable the mixed proxy, allowing this section to route traffic through both HTTP and SOCKS proxies"
 msgstr ""
 
@@ -291,35 +295,35 @@ msgstr ""
 msgid "Enable YACD WAN Access"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:65
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:66
 msgid "Enter complete outbound configuration in JSON format"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:425
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:426
 msgid "Enter domain names separated by commas, spaces, or newlines. You can add comments using //"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:399
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:400
 msgid "Enter domain names without protocols, e.g. example.com or sub.example.com"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:479
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:480
 msgid "Enter subnets in CIDR notation (e.g. 103.21.244.0/22) or single IP addresses"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:137
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:138
 msgid "Every 1 minute"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:138
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:139
 msgid "Every 3 minutes"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:136
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:137
 msgid "Every 30 seconds"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:139
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:140
 msgid "Every 5 minutes"
 msgstr ""
 
@@ -339,17 +343,17 @@ msgstr ""
 #: src/podkop/tabs/diagnostic/initController.ts:231
 #: src/podkop/tabs/diagnostic/initController.ts:261
 #: src/podkop/tabs/diagnostic/initController.ts:265
-#: src/podkop/tabs/diagnostic/initController.ts:299
-#: src/podkop/tabs/diagnostic/initController.ts:303
+#: src/podkop/tabs/diagnostic/initController.ts:302
+#: src/podkop/tabs/diagnostic/initController.ts:306
 msgid "Failed to execute!"
 msgstr ""
 
-#: src/podkop/methods/custom/getDashboardSections.ts:117
+#: src/podkop/methods/custom/getDashboardSections.ts:148
 #: src/podkop/tabs/diagnostic/checks/runSectionsCheck.ts:59
 msgid "Fastest"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:637
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:638
 msgid "Fully Routed IPs"
 msgstr ""
 
@@ -559,7 +563,7 @@ msgstr ""
 msgid "Issues detected"
 msgstr ""
 
-#: src/podkop/tabs/diagnostic/initController.ts:453
+#: src/podkop/tabs/diagnostic/initController.ts:456
 msgid "Latest"
 msgstr ""
 
@@ -567,11 +571,11 @@ msgstr ""
 msgid "List Update Frequency"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:545
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:546
 msgid "Local Domain Lists"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:568
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:569
 msgid "Local Subnet Lists"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Memory Usage"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:673
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:678
 msgid "Mixed Proxy Port"
 msgstr ""
 
@@ -595,11 +599,11 @@ msgstr ""
 msgid "Monitored Interfaces"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:163
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:164
 msgid "Must be a number in the range of 50 - 1000"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:207
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:208
 msgid "Network Interface"
 msgstr ""
 
@@ -629,15 +633,15 @@ msgstr ""
 msgid "Operation timed out"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:28
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:29
 msgid "Outbound Config"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:64
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:65
 msgid "Outbound Configuration"
 msgstr ""
 
-#: src/podkop/tabs/diagnostic/initController.ts:443
+#: src/podkop/tabs/diagnostic/initController.ts:446
 msgid "Outdated"
 msgstr ""
 
@@ -681,7 +685,7 @@ msgstr ""
 msgid "Podkop will not modify your DHCP configuration"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:35
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:36
 msgid "Proxy Configuration URL"
 msgstr ""
 
@@ -693,16 +697,20 @@ msgstr ""
 msgid "Proxy traffic is routed via FakeIP"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:332
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:333
 msgid "Regional options cannot be used together"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:591
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:592
 msgid "Remote Domain Lists"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:614
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:615
 msgid "Remote Subnet Lists"
+msgstr ""
+
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:690
+msgid "Resolve real IP for routing"
 msgstr ""
 
 #: src/podkop/tabs/diagnostic/partials/renderAvailableActions.ts:49
@@ -749,7 +757,7 @@ msgstr ""
 msgid "Run Diagnostic"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:351
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:352
 msgid "Russia inside restrictions"
 msgstr ""
 
@@ -761,7 +769,7 @@ msgstr ""
 msgid "Sections"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:299
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:300
 msgid "Select a predefined list for routing"
 msgstr ""
 
@@ -777,15 +785,15 @@ msgstr ""
 msgid "Select how often the domain or subnet lists are updated automatically"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:23
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:24
 msgid "Select how to configure the proxy"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:208
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:209
 msgid "Select network interface for VPN connection"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:277
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:278
 #: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:25
 msgid "Select or enter DNS server address"
 msgstr ""
@@ -798,15 +806,15 @@ msgstr ""
 msgid "Select path for sing-box config file. Change this ONLY if you know what you are doing"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:264
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:265
 msgid "Select the DNS protocol type for the domain resolver"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:387
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:388
 msgid "Select the list type for adding custom domains"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:467
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:468
 msgid "Select the list type for adding custom subnets"
 msgstr ""
 
@@ -826,11 +834,11 @@ msgstr ""
 msgid "Select the WAN interfaces to be monitored"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:26
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:27
 msgid "Selector"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:87
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:88
 msgid "Selector Proxy Links"
 msgstr ""
 
@@ -883,20 +891,20 @@ msgstr ""
 msgid "Specify a local IP address to be excluded from routing"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:638
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:639
 msgid "Specify local IP addresses or subnets whose traffic will always be routed through the configured route"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:592
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:593
 msgid "Specify remote URLs to download and use domain lists"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:615
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:616
 msgid "Specify remote URLs to download and use subnet lists"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:546
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:569
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:547
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:570
 msgid "Specify the path to the list file located on the router filesystem"
 msgstr ""
 
@@ -928,8 +936,8 @@ msgstr ""
 msgid "Test latency"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:391
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:471
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:392
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:472
 msgid "Text List"
 msgstr ""
 
@@ -937,15 +945,15 @@ msgstr ""
 msgid "The DNS server used to look up the IP address of an upstream DNS server"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:134
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:135
 msgid "The interval between connectivity tests"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:147
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:148
 msgid "The maximum difference in response times (ms) allowed when comparing servers"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:170
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:171
 msgid "The URL used to test server connectivity"
 msgstr ""
 
@@ -973,12 +981,12 @@ msgstr ""
 msgid "TTL value cannot be empty"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:268
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:269
 #: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:17
 msgid "UDP (Unprotected DNS)"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:197
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:198
 msgid "UDP over TCP"
 msgstr ""
 
@@ -988,7 +996,7 @@ msgstr ""
 #: src/podkop/tabs/diagnostic/initController.ts:41
 #: src/podkop/tabs/diagnostic/initController.ts:42
 #: src/podkop/tabs/diagnostic/initController.ts:43
-#: src/podkop/tabs/diagnostic/initController.ts:417
+#: src/podkop/tabs/diagnostic/initController.ts:420
 msgid "unknown"
 msgstr ""
 
@@ -1009,47 +1017,47 @@ msgstr ""
 msgid "URL must use one of the following protocols:"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:27
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:28
 msgid "URLTest"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:133
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:134
 msgid "URLTest Check Interval"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:110
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:111
 msgid "URLTest Proxy Links"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:169
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:170
 msgid "URLTest Testing URL"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:146
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:147
 msgid "URLTest Tolerance"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:386
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:387
 msgid "User Domain List Type"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:398
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:399
 msgid "User Domains"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:424
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:425
 msgid "User Domains List"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:466
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:467
 msgid "User Subnet List Type"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:478
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:479
 msgid "User Subnets"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:504
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:505
 msgid "User Subnets List"
 msgstr ""
 
@@ -1070,8 +1078,8 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:457
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:536
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:458
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:537
 msgid "Validation errors:"
 msgstr ""
 
@@ -1084,17 +1092,17 @@ msgstr ""
 msgid "Visit Wiki"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:36
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:88
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:111
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:37
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:89
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:112
 msgid "vless://, ss://, trojan://, socks4/5://, hy2/hysteria2:// links"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:334
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:335
 msgid "Warning: %s cannot be used together with %s. Previous selections have been removed."
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:353
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:354
 msgid "Warning: Russia inside can only be used with %s. %s already in Russia inside and have been removed from selection."
 msgstr ""
 

--- a/fe-app-podkop/locales/podkop.ru.po
+++ b/fe-app-podkop/locales/podkop.ru.po
@@ -1,15 +1,15 @@
 # RU translations for PODKOP package.
 # Copyright (C) 2026 THE PODKOP'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PODKOP package.
-# divocatt, 2026.
+# romanvht, 2026.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PODKOP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-14 20:21+0200\n"
-"PO-Revision-Date: 2026-01-14 20:21+0200\n"
-"Last-Translator: divocatt\n"
+"POT-Creation-Date: 2026-05-09 12:50+1000\n"
+"PO-Revision-Date: 2026-05-09 12:50+1000\n"
+"Last-Translator: romanvht\n"
 "Language-Team: none\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
@@ -196,6 +196,9 @@ msgstr "Включить автостарт"
 
 msgid "Enable built-in DNS resolver for domains handled by this section"
 msgstr "Включить встроенный DNS-резолвер для доменов, обрабатываемых в этом разделе"
+
+msgid "Enable DNS resolve to get real IP when routing"
+msgstr "Включить разрешение DNS вне FakeIP для получения реальных IP-адресов при маршрутизации"
 
 msgid "Enable Mixed Proxy"
 msgstr "Включить смешанный прокси"
@@ -508,6 +511,9 @@ msgstr "Внешние списки доменов"
 
 msgid "Remote Subnet Lists"
 msgstr "Внешние списки подсетей"
+
+msgid "Resolve real IP for routing"
+msgstr "Получать реальный IP при роутинге"
 
 msgid "Restart podkop"
 msgstr "Перезапустить Podkop"

--- a/fe-app-podkop/locales/podkop.ru.po
+++ b/fe-app-podkop/locales/podkop.ru.po
@@ -198,7 +198,7 @@ msgid "Enable built-in DNS resolver for domains handled by this section"
 msgstr "Включить встроенный DNS-резолвер для доменов, обрабатываемых в этом разделе"
 
 msgid "Enable DNS resolve to get real IP when routing"
-msgstr "Включить разрешение DNS вне FakeIP для получения реальных IP-адресов при маршрутизации"
+msgstr "Разрешать домены в реальные IP-адреса перед маршрутизацией в outbound"
 
 msgid "Enable Mixed Proxy"
 msgstr "Включить смешанный прокси"
@@ -513,7 +513,7 @@ msgid "Remote Subnet Lists"
 msgstr "Внешние списки подсетей"
 
 msgid "Resolve real IP for routing"
-msgstr "Получать реальный IP при роутинге"
+msgstr "Разрешение реальных IP-адресов"
 
 msgid "Restart podkop"
 msgstr "Перезапустить Podkop"

--- a/luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js
+++ b/luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js
@@ -683,6 +683,17 @@ function createSectionContent(section) {
   );
   o.rmempty = false;
   o.depends("mixed_proxy_enabled", "1");
+
+  o = section.option(
+    form.Flag,
+    "resolve_real_ip_for_routing",
+    _("Resolve real IP for routing"),
+    _("Enable DNS resolve to get real IP when routing"),
+  );
+  o.default = "0";
+  o.rmempty = false;
+  o.depends("connection_type", "proxy");
+  o.depends("connection_type", "vpn");
 }
 
 const EntryPoint = {

--- a/luci-app-podkop/po/ru/podkop.po
+++ b/luci-app-podkop/po/ru/podkop.po
@@ -1,15 +1,15 @@
 # RU translations for PODKOP package.
 # Copyright (C) 2026 THE PODKOP'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PODKOP package.
-# divocatt, 2026.
+# romanvht, 2026.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PODKOP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-14 20:21+0200\n"
-"PO-Revision-Date: 2026-01-14 20:21+0200\n"
-"Last-Translator: divocatt\n"
+"POT-Creation-Date: 2026-05-09 12:50+1000\n"
+"PO-Revision-Date: 2026-05-09 12:50+1000\n"
+"Last-Translator: romanvht\n"
 "Language-Team: none\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
@@ -196,6 +196,9 @@ msgstr "Включить автостарт"
 
 msgid "Enable built-in DNS resolver for domains handled by this section"
 msgstr "Включить встроенный DNS-резолвер для доменов, обрабатываемых в этом разделе"
+
+msgid "Enable DNS resolve to get real IP when routing"
+msgstr "Включить разрешение DNS вне FakeIP для получения реальных IP-адресов при маршрутизации"
 
 msgid "Enable Mixed Proxy"
 msgstr "Включить смешанный прокси"
@@ -431,12 +434,6 @@ msgstr "Использование памяти"
 msgid "Mixed Proxy Port"
 msgstr "Порт смешанного прокси"
 
-msgid "Resolve real IP for routing"
-msgstr "Получать реальный IP при роутинге"
-
-msgid "Enable DNS resolve to get real IP when routing"
-msgstr "Включить разрешение DNS вне FakeIP для получения реальных IP-адресов при маршрутизации"
-
 msgid "Monitored Interfaces"
 msgstr "Наблюдаемые интерфейсы"
 
@@ -514,6 +511,9 @@ msgstr "Внешние списки доменов"
 
 msgid "Remote Subnet Lists"
 msgstr "Внешние списки подсетей"
+
+msgid "Resolve real IP for routing"
+msgstr "Получать реальный IP при роутинге"
 
 msgid "Restart podkop"
 msgstr "Перезапустить Podkop"

--- a/luci-app-podkop/po/ru/podkop.po
+++ b/luci-app-podkop/po/ru/podkop.po
@@ -431,6 +431,12 @@ msgstr "Использование памяти"
 msgid "Mixed Proxy Port"
 msgstr "Порт смешанного прокси"
 
+msgid "Resolve real IP for routing"
+msgstr "Получать реальный IP при роутинге"
+
+msgid "Enable DNS resolve to get real IP when routing"
+msgstr "Включить разрешение DNS вне FakeIP для получения реальных IP-адресов при маршрутизации"
+
 msgid "Monitored Interfaces"
 msgstr "Наблюдаемые интерфейсы"
 

--- a/luci-app-podkop/po/ru/podkop.po
+++ b/luci-app-podkop/po/ru/podkop.po
@@ -198,7 +198,7 @@ msgid "Enable built-in DNS resolver for domains handled by this section"
 msgstr "Включить встроенный DNS-резолвер для доменов, обрабатываемых в этом разделе"
 
 msgid "Enable DNS resolve to get real IP when routing"
-msgstr "Включить разрешение DNS вне FakeIP для получения реальных IP-адресов при маршрутизации"
+msgstr "Разрешать домены в реальные IP-адреса перед маршрутизацией в outbound"
 
 msgid "Enable Mixed Proxy"
 msgstr "Включить смешанный прокси"
@@ -513,7 +513,7 @@ msgid "Remote Subnet Lists"
 msgstr "Внешние списки подсетей"
 
 msgid "Resolve real IP for routing"
-msgstr "Получать реальный IP при роутинге"
+msgstr "Разрешение реальных IP-адресов"
 
 msgid "Restart podkop"
 msgstr "Перезапустить Podkop"

--- a/luci-app-podkop/po/templates/podkop.pot
+++ b/luci-app-podkop/po/templates/podkop.pot
@@ -283,6 +283,14 @@ msgstr ""
 msgid "Enable the mixed proxy, allowing this section to route traffic through both HTTP and SOCKS proxies"
 msgstr ""
 
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:678
+msgid "Resolve real IP for routing"
+msgstr ""
+
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:679
+msgid "Enable DNS resolve to get real IP when routing"
+msgstr ""
+
 #: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:237
 msgid "Enable YACD"
 msgstr ""

--- a/luci-app-podkop/po/templates/podkop.pot
+++ b/luci-app-podkop/po/templates/podkop.pot
@@ -1,15 +1,15 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2026 THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PODKOP package.
-# divocatt <210179590+divocatt@users.noreply.github.com>, 2026.
+# romanvht <romanvht@gmail.com>, 2026.
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PODKOP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-14 18:21+0200\n"
-"PO-Revision-Date: 2026-01-14 18:21+0200\n"
-"Last-Translator: divocatt <210179590+divocatt@users.noreply.github.com>\n"
+"POT-Creation-Date: 2026-05-09 02:49+1000\n"
+"PO-Revision-Date: 2026-05-09 02:49+1000\n"
+"Last-Translator: romanvht <romanvht@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -44,15 +44,15 @@ msgstr ""
 msgid "Allows access to YACD from the WAN. Make sure to open the appropriate port in your firewall."
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:198
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:199
 msgid "Applicable for SOCKS and Shadowsocks proxy"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:443
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:444
 msgid "At least one valid domain must be specified. Comments-only content is not allowed."
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:524
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:525
 msgid "At least one valid subnet or IP must be specified. Comments-only content is not allowed."
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:298
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:299
 msgid "Community Lists"
 msgstr ""
 
@@ -131,7 +131,7 @@ msgstr ""
 msgid "Configuration for Podkop service"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:22
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:23
 msgid "Configuration Type"
 msgstr ""
 
@@ -139,7 +139,7 @@ msgstr ""
 msgid "Connection Type"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:25
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:26
 msgid "Connection URL"
 msgstr ""
 
@@ -187,8 +187,8 @@ msgstr ""
 msgid "Disable the QUIC protocol to improve compatibility or fix issues with video streaming"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:389
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:469
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:390
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:470
 msgid "Disabled"
 msgstr ""
 
@@ -196,17 +196,17 @@ msgstr ""
 msgid "DNS on router"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:266
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:267
 #: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:15
 msgid "DNS over HTTPS (DoH)"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:267
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:268
 #: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:16
 msgid "DNS over TLS (DoT)"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:263
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:264
 #: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:12
 msgid "DNS Protocol Type"
 msgstr ""
@@ -215,7 +215,7 @@ msgstr ""
 msgid "DNS Rewrite TTL"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:276
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:277
 #: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:24
 msgid "DNS Server"
 msgstr ""
@@ -228,7 +228,7 @@ msgstr ""
 msgid "Do not panic, everything can be fixed, just..."
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:253
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:254
 msgid "Domain Resolver"
 msgstr ""
 
@@ -258,8 +258,8 @@ msgstr ""
 msgid "Downloading all lists via specific Proxy/VPN"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:390
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:470
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:391
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:471
 msgid "Dynamic List"
 msgstr ""
 
@@ -267,11 +267,15 @@ msgstr ""
 msgid "Enable autostart"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:254
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:255
 msgid "Enable built-in DNS resolver for domains handled by this section"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:662
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:691
+msgid "Enable DNS resolve to get real IP when routing"
+msgstr ""
+
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:665
 msgid "Enable Mixed Proxy"
 msgstr ""
 
@@ -279,16 +283,8 @@ msgstr ""
 msgid "Enable Output Network Interface"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:663
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:666
 msgid "Enable the mixed proxy, allowing this section to route traffic through both HTTP and SOCKS proxies"
-msgstr ""
-
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:678
-msgid "Resolve real IP for routing"
-msgstr ""
-
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:679
-msgid "Enable DNS resolve to get real IP when routing"
 msgstr ""
 
 #: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:237
@@ -299,35 +295,35 @@ msgstr ""
 msgid "Enable YACD WAN Access"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:65
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:66
 msgid "Enter complete outbound configuration in JSON format"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:425
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:426
 msgid "Enter domain names separated by commas, spaces, or newlines. You can add comments using //"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:399
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:400
 msgid "Enter domain names without protocols, e.g. example.com or sub.example.com"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:479
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:480
 msgid "Enter subnets in CIDR notation (e.g. 103.21.244.0/22) or single IP addresses"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:137
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:138
 msgid "Every 1 minute"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:138
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:139
 msgid "Every 3 minutes"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:136
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:137
 msgid "Every 30 seconds"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:139
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:140
 msgid "Every 5 minutes"
 msgstr ""
 
@@ -347,17 +343,17 @@ msgstr ""
 #: src/podkop/tabs/diagnostic/initController.ts:231
 #: src/podkop/tabs/diagnostic/initController.ts:261
 #: src/podkop/tabs/diagnostic/initController.ts:265
-#: src/podkop/tabs/diagnostic/initController.ts:299
-#: src/podkop/tabs/diagnostic/initController.ts:303
+#: src/podkop/tabs/diagnostic/initController.ts:302
+#: src/podkop/tabs/diagnostic/initController.ts:306
 msgid "Failed to execute!"
 msgstr ""
 
-#: src/podkop/methods/custom/getDashboardSections.ts:117
+#: src/podkop/methods/custom/getDashboardSections.ts:148
 #: src/podkop/tabs/diagnostic/checks/runSectionsCheck.ts:59
 msgid "Fastest"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:637
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:638
 msgid "Fully Routed IPs"
 msgstr ""
 
@@ -567,7 +563,7 @@ msgstr ""
 msgid "Issues detected"
 msgstr ""
 
-#: src/podkop/tabs/diagnostic/initController.ts:453
+#: src/podkop/tabs/diagnostic/initController.ts:456
 msgid "Latest"
 msgstr ""
 
@@ -575,11 +571,11 @@ msgstr ""
 msgid "List Update Frequency"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:545
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:546
 msgid "Local Domain Lists"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:568
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:569
 msgid "Local Subnet Lists"
 msgstr ""
 
@@ -595,7 +591,7 @@ msgstr ""
 msgid "Memory Usage"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:673
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:678
 msgid "Mixed Proxy Port"
 msgstr ""
 
@@ -603,11 +599,11 @@ msgstr ""
 msgid "Monitored Interfaces"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:163
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:164
 msgid "Must be a number in the range of 50 - 1000"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:207
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:208
 msgid "Network Interface"
 msgstr ""
 
@@ -637,15 +633,15 @@ msgstr ""
 msgid "Operation timed out"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:28
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:29
 msgid "Outbound Config"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:64
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:65
 msgid "Outbound Configuration"
 msgstr ""
 
-#: src/podkop/tabs/diagnostic/initController.ts:443
+#: src/podkop/tabs/diagnostic/initController.ts:446
 msgid "Outdated"
 msgstr ""
 
@@ -689,7 +685,7 @@ msgstr ""
 msgid "Podkop will not modify your DHCP configuration"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:35
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:36
 msgid "Proxy Configuration URL"
 msgstr ""
 
@@ -701,16 +697,20 @@ msgstr ""
 msgid "Proxy traffic is routed via FakeIP"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:332
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:333
 msgid "Regional options cannot be used together"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:591
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:592
 msgid "Remote Domain Lists"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:614
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:615
 msgid "Remote Subnet Lists"
+msgstr ""
+
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:690
+msgid "Resolve real IP for routing"
 msgstr ""
 
 #: src/podkop/tabs/diagnostic/partials/renderAvailableActions.ts:49
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Run Diagnostic"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:351
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:352
 msgid "Russia inside restrictions"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "Sections"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:299
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:300
 msgid "Select a predefined list for routing"
 msgstr ""
 
@@ -785,15 +785,15 @@ msgstr ""
 msgid "Select how often the domain or subnet lists are updated automatically"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:23
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:24
 msgid "Select how to configure the proxy"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:208
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:209
 msgid "Select network interface for VPN connection"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:277
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:278
 #: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:25
 msgid "Select or enter DNS server address"
 msgstr ""
@@ -806,15 +806,15 @@ msgstr ""
 msgid "Select path for sing-box config file. Change this ONLY if you know what you are doing"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:264
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:265
 msgid "Select the DNS protocol type for the domain resolver"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:387
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:388
 msgid "Select the list type for adding custom domains"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:467
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:468
 msgid "Select the list type for adding custom subnets"
 msgstr ""
 
@@ -834,11 +834,11 @@ msgstr ""
 msgid "Select the WAN interfaces to be monitored"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:26
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:27
 msgid "Selector"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:87
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:88
 msgid "Selector Proxy Links"
 msgstr ""
 
@@ -891,20 +891,20 @@ msgstr ""
 msgid "Specify a local IP address to be excluded from routing"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:638
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:639
 msgid "Specify local IP addresses or subnets whose traffic will always be routed through the configured route"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:592
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:593
 msgid "Specify remote URLs to download and use domain lists"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:615
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:616
 msgid "Specify remote URLs to download and use subnet lists"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:546
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:569
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:547
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:570
 msgid "Specify the path to the list file located on the router filesystem"
 msgstr ""
 
@@ -936,8 +936,8 @@ msgstr ""
 msgid "Test latency"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:391
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:471
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:392
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:472
 msgid "Text List"
 msgstr ""
 
@@ -945,15 +945,15 @@ msgstr ""
 msgid "The DNS server used to look up the IP address of an upstream DNS server"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:134
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:135
 msgid "The interval between connectivity tests"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:147
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:148
 msgid "The maximum difference in response times (ms) allowed when comparing servers"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:170
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:171
 msgid "The URL used to test server connectivity"
 msgstr ""
 
@@ -981,12 +981,12 @@ msgstr ""
 msgid "TTL value cannot be empty"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:268
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:269
 #: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/settings.js:17
 msgid "UDP (Unprotected DNS)"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:197
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:198
 msgid "UDP over TCP"
 msgstr ""
 
@@ -996,7 +996,7 @@ msgstr ""
 #: src/podkop/tabs/diagnostic/initController.ts:41
 #: src/podkop/tabs/diagnostic/initController.ts:42
 #: src/podkop/tabs/diagnostic/initController.ts:43
-#: src/podkop/tabs/diagnostic/initController.ts:417
+#: src/podkop/tabs/diagnostic/initController.ts:420
 msgid "unknown"
 msgstr ""
 
@@ -1017,47 +1017,47 @@ msgstr ""
 msgid "URL must use one of the following protocols:"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:27
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:28
 msgid "URLTest"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:133
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:134
 msgid "URLTest Check Interval"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:110
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:111
 msgid "URLTest Proxy Links"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:169
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:170
 msgid "URLTest Testing URL"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:146
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:147
 msgid "URLTest Tolerance"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:386
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:387
 msgid "User Domain List Type"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:398
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:399
 msgid "User Domains"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:424
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:425
 msgid "User Domains List"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:466
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:467
 msgid "User Subnet List Type"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:478
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:479
 msgid "User Subnets"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:504
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:505
 msgid "User Subnets List"
 msgstr ""
 
@@ -1078,8 +1078,8 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:457
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:536
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:458
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:537
 msgid "Validation errors:"
 msgstr ""
 
@@ -1092,17 +1092,17 @@ msgstr ""
 msgid "Visit Wiki"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:36
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:88
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:111
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:37
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:89
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:112
 msgid "vless://, ss://, trojan://, socks4/5://, hy2/hysteria2:// links"
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:334
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:335
 msgid "Warning: %s cannot be used together with %s. Previous selections have been removed."
 msgstr ""
 
-#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:353
+#: ../luci-app-podkop/htdocs/luci-static/resources/view/podkop/section.js:354
 msgid "Warning: Russia inside can only be used with %s. %s already in Russia inside and have been removed from selection."
 msgstr ""
 

--- a/podkop/files/usr/bin/podkop
+++ b/podkop/files/usr/bin/podkop
@@ -918,7 +918,7 @@ configure_routing_for_section_lists() {
     fi
 
     local community_lists user_domain_list_type user_subnet_list_type local_domain_lists local_subnet_lists \
-        remote_domain_lists remote_subnet_lists section_connection_type route_rule_tag
+        remote_domain_lists remote_subnet_lists section_connection_type route_rule_tag resolve_real_ip_for_routing
     config_get community_lists "$section" "community_lists"
     config_get user_domain_list_type "$section" "user_domain_list_type" "disabled"
     config_get user_subnet_list_type "$section" "user_subnet_list_type" "disabled"
@@ -927,6 +927,7 @@ configure_routing_for_section_lists() {
     config_get remote_domain_lists "$section" "remote_domain_lists"
     config_get remote_subnet_lists "$section" "remote_subnet_lists"
     config_get section_connection_type "$section" "connection_type"
+    config_get_bool resolve_real_ip_for_routing "$section" "resolve_real_ip_for_routing" 0
 
     case "$section_connection_type" in
     proxy | vpn)
@@ -981,6 +982,11 @@ configure_routing_for_section_lists() {
         log "Processing remote subnets routing rules for '$section' section"
         config_list_foreach "$section" "remote_subnet_lists" configure_remote_domain_or_subnet_list_handler \
             "subnets" "$section" "$route_rule_tag"
+    fi
+
+    if [ "$resolve_real_ip_for_routing" -eq 1 ]; then
+        config=$(sing_box_cm_add_resolve_rule "$config" "$route_rule_tag" "$(gen_id)" "$SB_DNS_SERVER_TAG")
+        log "Added resolve rule for '$section' section" "debug"
     fi
 }
 

--- a/podkop/files/usr/lib/sing_box_config_manager.sh
+++ b/podkop/files/usr/lib/sing_box_config_manager.sh
@@ -1091,6 +1091,42 @@ sing_box_cm_add_route_rule() {
 }
 
 #######################################
+# Insert a resolve rule immediately before a route rule.
+# Copies rule_set from the target route rule.
+# Arguments:
+#   config: string (JSON), sing-box configuration to modify
+#   route_rule_tag: string, tag of the route rule to precede
+#   resolve_rule_tag: string, tag for the new resolve rule
+#   server: string, DNS server tag (optional, default: "dns-server")
+# Outputs:
+#   Updated JSON config to stdout
+#######################################
+sing_box_cm_add_resolve_rule() {
+    local config="$1"
+    local route_rule_tag="$2"
+    local resolve_rule_tag="$3"
+    local server="${4:-dns-server}"
+
+    echo "$config" | jq \
+        --arg service_tag "$SERVICE_TAG" \
+        --arg route_tag "$route_rule_tag" \
+        --arg resolve_tag "$resolve_rule_tag" \
+        --arg server "$server" \
+        '.route.rules |= [
+            .[] | 
+            if .[$service_tag] == $route_tag then
+                {
+                    action: "resolve",
+                    rule_set: (.rule_set // []),
+                    server: $server,
+                    ($service_tag): $resolve_tag
+                }, .
+            else .
+            end
+        ]'
+}
+
+#######################################
 # Patch a routing rule in the route section of a sing-box JSON configuration.
 # Arguments:
 #   config: string (JSON), sing-box configuration to modify


### PR DESCRIPTION
Касается проблемы:  
https://github.com/hufrea/byedpi/issues/293

Добавляет для секции флаг **Получать реальный IP при роутинге**.

При генерации конфига sing-box перед route-правилом секции будет автоматически добавляться правило с `action: "resolve"` и продублированными `rule_set` из секции:

```json
{
  "action": "resolve",
  "rule_set": [
    "byedpi-youtube-community-ruleset",
    "byedpi-user-domains-ruleset"
  ],
  "server": "dns-server"
},
{
  "action": "route",
  "inbound": "tproxy-in",
  "outbound": "byedpi-out",
  "rule_set": [
    "byedpi-youtube-community-ruleset",
    "byedpi-user-domains-ruleset"
  ]
}
```

`action: "resolve"` заставит коробку выполнить повторное разрешение IP через DNS-сервер, указанный в настройках Podkop. Благодаря этому в byedpi передаётся реальный IP-адрес вместо fakeip, и он не пытается резолвить адрес самостоятельно снова через коробку.