### PR TITLE
Fix/fix version check

### DIFF
--- a/fe-app-podkop/src/helpers/removeVersionPrefix.ts
+++ b/fe-app-podkop/src/helpers/removeVersionPrefix.ts
@@ -1,1 +1,3 @@
-export const removeVersionPrefix = (v: string) => v.replace(/^v/, '');
+export function removeVersionPrefix(version: string) {
+  return version.replace(/^v/, '');
+}

--- a/fe-app-podkop/src/helpers/removeVersionPrefix.ts
+++ b/fe-app-podkop/src/helpers/removeVersionPrefix.ts
@@ -1,0 +1,1 @@
+export const removeVersionPrefix = (v: string) => v.replace(/^v/, '');

--- a/fe-app-podkop/src/podkop/tabs/diagnostic/helpers/getPodkopVersionRow.ts
+++ b/fe-app-podkop/src/podkop/tabs/diagnostic/helpers/getPodkopVersionRow.ts
@@ -1,0 +1,48 @@
+import { normalizeCompiledVersion } from '../../../../helpers/normalizeCompiledVersion';
+import { removeVersionPrefix } from '../../../../helpers/removeVersionPrefix';
+import type { StoreType } from '../../../services/store.service';
+import type { IRenderSystemInfoRow } from '../partials';
+
+export function getPodkopVersionRow(
+  diagnosticsSystemInfo: StoreType['diagnosticsSystemInfo'],
+): IRenderSystemInfoRow {
+  const loading = diagnosticsSystemInfo.loading;
+  const unknown = diagnosticsSystemInfo.podkop_version === _('unknown');
+  const hasActualVersion =
+    Boolean(diagnosticsSystemInfo.podkop_latest_version) &&
+    diagnosticsSystemInfo.podkop_latest_version !== 'unknown';
+  const version = normalizeCompiledVersion(
+    diagnosticsSystemInfo.podkop_version,
+  );
+  const isDevVersion = version === 'dev';
+
+  if (loading || unknown || !hasActualVersion || isDevVersion) {
+    return {
+      key: 'Podkop',
+      value: version,
+    };
+  }
+
+  if (
+    removeVersionPrefix(version) !==
+    removeVersionPrefix(diagnosticsSystemInfo.podkop_latest_version)
+  ) {
+    return {
+      key: 'Podkop',
+      value: version,
+      tag: {
+        label: _('Outdated'),
+        kind: 'warning',
+      },
+    };
+  }
+
+  return {
+    key: 'Podkop',
+    value: version,
+    tag: {
+      label: _('Latest'),
+      kind: 'success',
+    },
+  };
+}

--- a/fe-app-podkop/src/podkop/tabs/diagnostic/helpers/getPodkopVersionRow.ts
+++ b/fe-app-podkop/src/podkop/tabs/diagnostic/helpers/getPodkopVersionRow.ts
@@ -3,14 +3,18 @@ import { removeVersionPrefix } from '../../../../helpers/removeVersionPrefix';
 import type { StoreType } from '../../../services/store.service';
 import type { IRenderSystemInfoRow } from '../partials';
 
+function isUnknownVersion(version?: string | null): boolean {
+  return version === 'unknown' || version === _('unknown');
+}
+
 export function getPodkopVersionRow(
   diagnosticsSystemInfo: StoreType['diagnosticsSystemInfo'],
 ): IRenderSystemInfoRow {
   const loading = diagnosticsSystemInfo.loading;
-  const unknown = diagnosticsSystemInfo.podkop_version === _('unknown');
+  const unknown = isUnknownVersion(diagnosticsSystemInfo.podkop_version);
   const hasActualVersion =
     Boolean(diagnosticsSystemInfo.podkop_latest_version) &&
-    diagnosticsSystemInfo.podkop_latest_version !== 'unknown';
+    !isUnknownVersion(diagnosticsSystemInfo.podkop_latest_version);
   const version = normalizeCompiledVersion(
     diagnosticsSystemInfo.podkop_version,
   );

--- a/fe-app-podkop/src/podkop/tabs/diagnostic/initController.ts
+++ b/fe-app-podkop/src/podkop/tabs/diagnostic/initController.ts
@@ -6,7 +6,6 @@ import { runFakeIPCheck } from './checks/runFakeIPCheck';
 import { loadingDiagnosticsChecksStore } from './diagnostic.store';
 import { logger, store, StoreType } from '../../services';
 import {
-  IRenderSystemInfoRow,
   renderAvailableActions,
   renderCheckSection,
   renderRunAction,
@@ -20,6 +19,7 @@ import { PODKOP_LUCI_APP_VERSION } from '../../../constants';
 import { showToast } from '../../../helpers/showToast';
 import { renderWikiDisclaimer } from './partials/renderWikiDisclaimer';
 import { runSectionsCheck } from './checks/runSectionsCheck';
+import { getPodkopVersionRow } from './helpers/getPodkopVersionRow';
 
 async function fetchSystemInfo() {
   const systemInfo = await PodkopShellMethods.getSystemInfo();
@@ -415,53 +415,9 @@ function renderDiagnosticSystemInfoWidget() {
 
   const container = document.getElementById('pdk_diagnostic-page-system-info');
 
-  function getPodkopVersionRow(): IRenderSystemInfoRow {
-    const loading = diagnosticsSystemInfo.loading;
-    const unknown = diagnosticsSystemInfo.podkop_version === _('unknown');
-    const hasActualVersion =
-      Boolean(diagnosticsSystemInfo.podkop_latest_version) &&
-      diagnosticsSystemInfo.podkop_latest_version !== 'unknown';
-    const version = normalizeCompiledVersion(
-      diagnosticsSystemInfo.podkop_version,
-    );
-    const isDevVersion = version === 'dev';
-
-    if (loading || unknown || !hasActualVersion || isDevVersion) {
-      return {
-        key: 'Podkop',
-        value: version,
-      };
-    }
-
-    if (version !== diagnosticsSystemInfo.podkop_latest_version) {
-      logger.debug(
-        '[DIAGNOSTIC]',
-        'diagnosticsSystemInfo',
-        diagnosticsSystemInfo,
-      );
-      return {
-        key: 'Podkop',
-        value: version,
-        tag: {
-          label: _('Outdated'),
-          kind: 'warning',
-        },
-      };
-    }
-
-    return {
-      key: 'Podkop',
-      value: version,
-      tag: {
-        label: _('Latest'),
-        kind: 'success',
-      },
-    };
-  }
-
   const renderedSystemInfo = renderSystemInfo({
     items: [
-      getPodkopVersionRow(),
+      getPodkopVersionRow(diagnosticsSystemInfo),
       {
         key: 'Luci App',
         value: normalizeCompiledVersion(PODKOP_LUCI_APP_VERSION),

--- a/fe-app-podkop/src/podkop/tabs/diagnostic/tests/getPodkopVersionRow.test.ts
+++ b/fe-app-podkop/src/podkop/tabs/diagnostic/tests/getPodkopVersionRow.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { getPodkopVersionRow } from '../helpers/getPodkopVersionRow';
+import type { StoreType } from '../../../services/store.service';
+
+function makeDiagnosticsSystemInfo(
+  patch: Partial<StoreType['diagnosticsSystemInfo']> = {},
+): StoreType['diagnosticsSystemInfo'] {
+  return {
+    loading: false,
+    podkop_version: '1.2.3',
+    podkop_latest_version: '1.2.3',
+    luci_app_version: '1.0.0',
+    sing_box_version: '1.11.0',
+    openwrt_version: 'OpenWrt 25.12',
+    device_model: 'Test Router',
+    ...patch,
+  };
+}
+
+describe('getPodkopVersionRow', () => {
+  it('returns Latest when versions differ only by leading v', () => {
+    const row = getPodkopVersionRow(
+      makeDiagnosticsSystemInfo({
+        podkop_version: 'v1.2.3',
+        podkop_latest_version: '1.2.3',
+      }),
+    );
+
+    expect(row).toEqual({
+      key: 'Podkop',
+      value: 'v1.2.3',
+      tag: {
+        label: 'Latest',
+        kind: 'success',
+      },
+    });
+  });
+
+  it('returns Outdated when versions differ', () => {
+    const row = getPodkopVersionRow(
+      makeDiagnosticsSystemInfo({
+        podkop_version: '1.2.2',
+        podkop_latest_version: '1.2.3',
+      }),
+    );
+
+    expect(row).toEqual({
+      key: 'Podkop',
+      value: '1.2.2',
+      tag: {
+        label: 'Outdated',
+        kind: 'warning',
+      },
+    });
+  });
+
+  it('returns plain row without tag for dev build', () => {
+    const row = getPodkopVersionRow(
+      makeDiagnosticsSystemInfo({
+        podkop_version: 'COMPILED_VERSION',
+      }),
+    );
+
+    expect(row).toEqual({
+      key: 'Podkop',
+      value: 'dev',
+    });
+  });
+});

--- a/luci-app-podkop/htdocs/luci-static/resources/view/podkop/main.js
+++ b/luci-app-podkop/htdocs/luci-static/resources/view/podkop/main.js
@@ -3929,10 +3929,13 @@ async function runSectionsCheck() {
 var removeVersionPrefix = (v) => v.replace(/^v/, "");
 
 // src/podkop/tabs/diagnostic/helpers/getPodkopVersionRow.ts
+function isUnknownVersion(version) {
+  return version === "unknown" || version === _("unknown");
+}
 function getPodkopVersionRow(diagnosticsSystemInfo) {
   const loading = diagnosticsSystemInfo.loading;
-  const unknown = diagnosticsSystemInfo.podkop_version === _("unknown");
-  const hasActualVersion = Boolean(diagnosticsSystemInfo.podkop_latest_version) && diagnosticsSystemInfo.podkop_latest_version !== "unknown";
+  const unknown = isUnknownVersion(diagnosticsSystemInfo.podkop_version);
+  const hasActualVersion = Boolean(diagnosticsSystemInfo.podkop_latest_version) && !isUnknownVersion(diagnosticsSystemInfo.podkop_latest_version);
   const version = normalizeCompiledVersion(
     diagnosticsSystemInfo.podkop_version
   );

--- a/luci-app-podkop/htdocs/luci-static/resources/view/podkop/main.js
+++ b/luci-app-podkop/htdocs/luci-static/resources/view/podkop/main.js
@@ -3925,6 +3925,44 @@ async function runSectionsCheck() {
   }
 }
 
+// src/helpers/removeVersionPrefix.ts
+var removeVersionPrefix = (v) => v.replace(/^v/, "");
+
+// src/podkop/tabs/diagnostic/helpers/getPodkopVersionRow.ts
+function getPodkopVersionRow(diagnosticsSystemInfo) {
+  const loading = diagnosticsSystemInfo.loading;
+  const unknown = diagnosticsSystemInfo.podkop_version === _("unknown");
+  const hasActualVersion = Boolean(diagnosticsSystemInfo.podkop_latest_version) && diagnosticsSystemInfo.podkop_latest_version !== "unknown";
+  const version = normalizeCompiledVersion(
+    diagnosticsSystemInfo.podkop_version
+  );
+  const isDevVersion = version === "dev";
+  if (loading || unknown || !hasActualVersion || isDevVersion) {
+    return {
+      key: "Podkop",
+      value: version
+    };
+  }
+  if (removeVersionPrefix(version) !== removeVersionPrefix(diagnosticsSystemInfo.podkop_latest_version)) {
+    return {
+      key: "Podkop",
+      value: version,
+      tag: {
+        label: _("Outdated"),
+        kind: "warning"
+      }
+    };
+  }
+  return {
+    key: "Podkop",
+    value: version,
+    tag: {
+      label: _("Latest"),
+      kind: "success"
+    }
+  };
+}
+
 // src/podkop/tabs/diagnostic/initController.ts
 async function fetchSystemInfo() {
   const systemInfo = await PodkopShellMethods.getSystemInfo();
@@ -4272,47 +4310,9 @@ function renderDiagnosticSystemInfoWidget() {
   logger.debug("[DIAGNOSTIC]", "renderDiagnosticSystemInfoWidget");
   const diagnosticsSystemInfo = store.get().diagnosticsSystemInfo;
   const container = document.getElementById("pdk_diagnostic-page-system-info");
-  function getPodkopVersionRow() {
-    const loading = diagnosticsSystemInfo.loading;
-    const unknown = diagnosticsSystemInfo.podkop_version === _("unknown");
-    const hasActualVersion = Boolean(diagnosticsSystemInfo.podkop_latest_version) && diagnosticsSystemInfo.podkop_latest_version !== "unknown";
-    const version = normalizeCompiledVersion(
-      diagnosticsSystemInfo.podkop_version
-    );
-    const isDevVersion = version === "dev";
-    if (loading || unknown || !hasActualVersion || isDevVersion) {
-      return {
-        key: "Podkop",
-        value: version
-      };
-    }
-    if (version !== diagnosticsSystemInfo.podkop_latest_version) {
-      logger.debug(
-        "[DIAGNOSTIC]",
-        "diagnosticsSystemInfo",
-        diagnosticsSystemInfo
-      );
-      return {
-        key: "Podkop",
-        value: version,
-        tag: {
-          label: _("Outdated"),
-          kind: "warning"
-        }
-      };
-    }
-    return {
-      key: "Podkop",
-      value: version,
-      tag: {
-        label: _("Latest"),
-        kind: "success"
-      }
-    };
-  }
   const renderedSystemInfo = renderSystemInfo({
     items: [
-      getPodkopVersionRow(),
+      getPodkopVersionRow(diagnosticsSystemInfo),
       {
         key: "Luci App",
         value: normalizeCompiledVersion(PODKOP_LUCI_APP_VERSION)

--- a/luci-app-podkop/htdocs/luci-static/resources/view/podkop/main.js
+++ b/luci-app-podkop/htdocs/luci-static/resources/view/podkop/main.js
@@ -3926,7 +3926,9 @@ async function runSectionsCheck() {
 }
 
 // src/helpers/removeVersionPrefix.ts
-var removeVersionPrefix = (v) => v.replace(/^v/, "");
+function removeVersionPrefix(version) {
+  return version.replace(/^v/, "");
+}
 
 // src/podkop/tabs/diagnostic/helpers/getPodkopVersionRow.ts
 function isUnknownVersion(version) {


### PR DESCRIPTION
# Описание изменений

Вынесена логика определения статуса версии Podkop в отдельный helper и покрыта тестами, исправлена ошибка из ишью https://github.com/itdoginfo/podkop/issues/278

## Что изменено

Детальное описание изменений:
- Добавлен helper `removeVersionPrefix.ts` для нормализации версий
- Логика `getPodkopVersionRow` вынесена из `initController.ts` в отдельный файл `src/podkop/tabs/diagnostic/helpers/getPodkopVersionRow.ts`.
- `initController.ts` обновлен: используется helper `getPodkopVersionRow(...)` вместо вложенной функции внутри `renderDiagnosticSystemInfoWidget`.
- Добавлен тест `src/podkop/tabs/diagnostic/tests/getPodkopVersionRow.test.ts`