### PR TITLE
Fix: Replace out-of-date `stirng` type with `string` in luci.d.ts

### DIFF
--- a/fe-app-podkop/src/luci.d.ts
+++ b/fe-app-podkop/src/luci.d.ts
@@ -37,7 +37,7 @@ declare global {
   const _ = (_key: string) => string;
 
   const ui = {
-    showModal: (_title: stirng, _content: HtmlElement) => undefined,
+    showModal: (_title: string, _content: HtmlElement) => undefined,
     hideModal: () => undefined,
     addNotification: (
       _title: string,


### PR DESCRIPTION
The type definition for `ui.showModal` incorrectly uses `stirng` instead of `string`. This will cause a TypeScript compilation error in strict mode. The fix corrects the typo, ensuring that the type declaration matches the actual LuCI API signature.