### PR TITLE
fix: use service_proxy_address for GitHub proxy connectivity check

### DIFF
--- a/podkop/files/usr/bin/podkop
+++ b/podkop/files/usr/bin/podkop
@@ -510,7 +510,7 @@ list_update() {
         local service_proxy_address
         service_proxy_address="$(get_service_proxy_address)"
 
-        if [ -n "$http_proxy_address" ]; then
+        if [ -n "$service_proxy_address" ]; then
             if curl -s -x "http://$service_proxy_address" -m $curl_timeout https://github.com > /dev/null; then
                 echolog "✅ GitHub connection check passed (via proxy)"
                 break


### PR DESCRIPTION
# Описание изменений

Исправление проверки доступности github.com через прокси при включеном параметре загрузки списков через прокси