### PR TITLE
LuCI: add cache-busting version for JS assets

### DIFF
--- a/fe-app-podkop/src/luci/tests/podkopAssetVersioning.test.js
+++ b/fe-app-podkop/src/luci/tests/podkopAssetVersioning.test.js
@@ -1,0 +1,174 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const podkopViewPath = resolve(
+  import.meta.dirname,
+  '../../../../luci-app-podkop/htdocs/luci-static/resources/view/podkop/podkop.js',
+);
+
+function createModuleMocks() {
+  return {
+    'view.podkop.main': {
+      injectGlobalStyles() {},
+      coreService() {},
+    },
+    'view.podkop.settings': {
+      createSettingsContent() {},
+    },
+    'view.podkop.section': {
+      createSectionContent() {},
+    },
+    'view.podkop.dashboard': {
+      createDashboardContent() {},
+    },
+    'view.podkop.diagnostic': {
+      createDiagnosticContent() {},
+    },
+  };
+}
+
+function createFormMock() {
+  class Map {
+    constructor() {
+      this.sections = [];
+    }
+
+    section() {
+      const section = {};
+      this.sections.push(section);
+      return section;
+    }
+
+    render() {
+      return 'rendered';
+    }
+  }
+
+  return {
+    Map,
+    TypedSection: class {},
+  };
+}
+
+function loadPodkopView({ compiledAssetVersion, uiAssetVersion }) {
+  const source = readFileSync(podkopViewPath, 'utf8').replaceAll(
+    '__COMPILED_ASSET_VERSION_VARIABLE__',
+    compiledAssetVersion,
+  );
+
+  const requireCalls = [];
+  const moduleMocks = createModuleMocks();
+  const L = {
+    env: {
+      resource_version: 'openwrt-resource-version',
+    },
+    require: async (name) => {
+      requireCalls.push({
+        name,
+        resourceVersion: L.env.resource_version,
+      });
+      return moduleMocks[name];
+    },
+  };
+
+  const uci = {
+    load: async () => {},
+    get: () => uiAssetVersion,
+  };
+
+  const view = {
+    extend: (entryPoint) => entryPoint,
+  };
+
+  const baseclass = {
+    extend: (entryPoint) => entryPoint,
+  };
+
+  const entryPoint = new Function(
+    'view',
+    'form',
+    'baseclass',
+    'network',
+    'uci',
+    'L',
+    '_',
+    source,
+  )(
+    view,
+    createFormMock(),
+    baseclass,
+    {},
+    uci,
+    L,
+    (value) => value,
+  );
+
+  return {
+    entryPoint,
+    L,
+    requireCalls,
+    source,
+  };
+}
+
+describe('podkop LuCI asset versioning', () => {
+  it('loads Podkop view modules with the UCI asset version', async () => {
+    const { entryPoint, L, requireCalls } = loadPodkopView({
+      compiledAssetVersion: '1.2.3-1',
+      uiAssetVersion: '1.2.3-4',
+    });
+
+    await expect(entryPoint.render()).resolves.toBe('rendered');
+
+    expect(requireCalls).toEqual([
+      {
+        name: 'view.podkop.main',
+        resourceVersion: 'podkop-1.2.3-4',
+      },
+      {
+        name: 'view.podkop.settings',
+        resourceVersion: 'podkop-1.2.3-4',
+      },
+      {
+        name: 'view.podkop.section',
+        resourceVersion: 'podkop-1.2.3-4',
+      },
+      {
+        name: 'view.podkop.dashboard',
+        resourceVersion: 'podkop-1.2.3-4',
+      },
+      {
+        name: 'view.podkop.diagnostic',
+        resourceVersion: 'podkop-1.2.3-4',
+      },
+    ]);
+    expect(L.env.resource_version).toBe('openwrt-resource-version');
+  });
+
+  it('falls back to the compiled asset version', async () => {
+    const { entryPoint, requireCalls } = loadPodkopView({
+      compiledAssetVersion: '2.0.0-7',
+      uiAssetVersion: '',
+    });
+
+    await expect(entryPoint.render()).resolves.toBe('rendered');
+
+    expect(
+      requireCalls.every(
+        ({ resourceVersion }) => resourceVersion === 'podkop-2.0.0-7',
+      ),
+    ).toBe(true);
+  });
+
+  it('sanitizes the asset version before using it in LuCI resource URLs', async () => {
+    const { entryPoint, requireCalls } = loadPodkopView({
+      compiledAssetVersion: '2.0.0-7',
+      uiAssetVersion: '2.0.0 release/7',
+    });
+
+    await expect(entryPoint.render()).resolves.toBe('rendered');
+
+    expect(requireCalls[0].resourceVersion).toBe('podkop-2.0.0_release_7');
+  });
+});

--- a/luci-app-podkop/Makefile
+++ b/luci-app-podkop/Makefile
@@ -5,6 +5,7 @@ PKG_NAME:=luci-app-podkop
 PKG_VERSION := $(if $(PODKOP_VERSION),$(PODKOP_VERSION),0.$(shell date +%d%m%Y))
 
 PKG_RELEASE:=1
+PODKOP_UI_ASSET_VERSION:=$(PKG_VERSION)-$(PKG_RELEASE)
 
 LUCI_TITLE:=LuCI podkop app
 LUCI_DEPENDS:=+luci-base +podkop
@@ -24,7 +25,11 @@ define Package/$(PKG_NAME)/install
 	$(CP) $(PKG_BUILD_DIR)/htdocs/* $(1)$(HTDOCS)/
 	$(INSTALL_DIR) $(1)/
 	$(CP) $(PKG_BUILD_DIR)/root/* $(1)/
-	sed -i -e 's/__COMPILED_VERSION_VARIABLE__/$(PKG_VERSION)/g' $(1)$(HTDOCS)/luci-static/resources/view/podkop/main.js || true
+	sed -i \
+		-e 's/__COMPILED_VERSION_VARIABLE__/$(PKG_VERSION)/g' \
+		-e 's/__COMPILED_ASSET_VERSION_VARIABLE__/$(PODKOP_UI_ASSET_VERSION)/g' \
+		$(1)$(HTDOCS)/luci-static/resources/view/podkop/*.js \
+		$(1)/etc/uci-defaults/50_luci-podkop || true
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/luci-app-podkop/htdocs/luci-static/resources/view/podkop/podkop.js
+++ b/luci-app-podkop/htdocs/luci-static/resources/view/podkop/podkop.js
@@ -3,22 +3,63 @@
 "require form";
 "require baseclass";
 "require network";
-"require view.podkop.main as main";
+"require uci";
 
-// Settings content
-"require view.podkop.settings as settings";
+const COMPILED_ASSET_VERSION = "__COMPILED_ASSET_VERSION_VARIABLE__";
+const UNCOMPILED_ASSET_VERSION = [
+  "__COMPILED",
+  "ASSET_VERSION_VARIABLE__",
+].join("_");
 
-// Sections content
-"require view.podkop.section as section";
+function sanitizeAssetVersion(version) {
+  return String(version || "").replace(/[^A-Za-z0-9_.~-]/g, "_");
+}
 
-// Dashboard content
-"require view.podkop.dashboard as dashboard";
+async function getAssetVersion() {
+  try {
+    await uci.load("podkop");
+    return (
+      uci.get("podkop", "settings", "ui_asset_version") ||
+      COMPILED_ASSET_VERSION
+    );
+  } catch (e) {
+    return COMPILED_ASSET_VERSION;
+  }
+}
 
-// Diagnostic content
-"require view.podkop.diagnostic as diagnostic";
+async function loadPodkopModules() {
+  const defaultResourceVersion = L.env.resource_version;
+  const assetVersion = sanitizeAssetVersion(await getAssetVersion());
+
+  if (
+    assetVersion &&
+    assetVersion !== UNCOMPILED_ASSET_VERSION
+  ) {
+    // Let LuCI append the Podkop package asset version to dynamically loaded
+    // view modules, so browsers fetch fresh UI code after package upgrades.
+    L.env.resource_version = `podkop-${assetVersion}`;
+  }
+
+  try {
+    const [main, settings, section, dashboard, diagnostic] = await Promise.all([
+      L.require("view.podkop.main"),
+      L.require("view.podkop.settings"),
+      L.require("view.podkop.section"),
+      L.require("view.podkop.dashboard"),
+      L.require("view.podkop.diagnostic"),
+    ]);
+
+    return { main, settings, section, dashboard, diagnostic };
+  } finally {
+    L.env.resource_version = defaultResourceVersion;
+  }
+}
 
 const EntryPoint = {
   async render() {
+    const { main, settings, section, dashboard, diagnostic } =
+      await loadPodkopModules();
+
     main.injectGlobalStyles();
 
     const podkopMap = new form.Map(

--- a/luci-app-podkop/root/etc/uci-defaults/50_luci-podkop
+++ b/luci-app-podkop/root/etc/uci-defaults/50_luci-podkop
@@ -2,6 +2,10 @@
 
 rm -f /var/luci-indexcache*
 rm -f /tmp/luci-indexcache*
+rm -f /tmp/luci-modulecache/*
+
+uci -q set podkop.settings.ui_asset_version='__COMPILED_ASSET_VERSION_VARIABLE__'
+uci -q commit podkop
 
 [ -x /etc/init.d/rpcd ] && /etc/init.d/rpcd reload
 


### PR DESCRIPTION
### What changed

- Added a LuCI asset version derived from package version/release.
- Store the asset version in `podkop.settings.ui_asset_version` during package install/update.
- Load Podkop LuCI view modules with a versioned LuCI resource parameter.
- Clear LuCI server-side index/module cache during install/update.

### Why

Browsers can keep old Podkop LuCI JS after package updates. Versioned resource URLs make LuCI request fresh UI modules when the package version changes, so users do not need to manually clear browser cache.

### Tests

- `git diff --check`
- Verified `podkop.js` syntax as a LuCI factory body with Node.js.
