### PR TITLE
LuCI: allow reordering sections

### DIFF
--- a/luci-app-podkop/htdocs/luci-static/resources/view/podkop/podkop.js
+++ b/luci-app-podkop/htdocs/luci-static/resources/view/podkop/podkop.js
@@ -39,8 +39,7 @@ const SortableTypedSection = form.TypedSection.extend({
           E(
             "button",
             {
-              class: "cbi-button cbi-button-neutral",
-              style: "border-color: currentColor",
+              class: "btn pdk-partial-button",
               title,
               click: ui.createHandlerFn(
                 this,

--- a/luci-app-podkop/htdocs/luci-static/resources/view/podkop/podkop.js
+++ b/luci-app-podkop/htdocs/luci-static/resources/view/podkop/podkop.js
@@ -59,14 +59,14 @@ const SortableTypedSection = form.TypedSection.extend({
 
       addMoveButton(
         _("Move up"),
-        "↑",
+        "🡅",
         sectionIds[index - 1],
         false,
         index === 0,
       );
       addMoveButton(
         _("Move down"),
-        "↓",
+        "🡇",
         sectionIds[index + 1],
         true,
         index === sectionIds.length - 1,

--- a/luci-app-podkop/htdocs/luci-static/resources/view/podkop/podkop.js
+++ b/luci-app-podkop/htdocs/luci-static/resources/view/podkop/podkop.js
@@ -1,6 +1,7 @@
 "use strict";
 "require view";
 "require form";
+"require ui";
 "require baseclass";
 "require network";
 "require view.podkop.main as main";
@@ -17,6 +18,65 @@
 // Diagnostic content
 "require view.podkop.diagnostic as diagnostic";
 
+const SortableTypedSection = form.TypedSection.extend({
+  handleMove(sectionId, referenceId, after) {
+    const configName = this.uciconfig ?? this.map.config;
+
+    if (this.map.data.move(configName, sectionId, referenceId, after)) {
+      return this.map.save(null, true);
+    }
+  },
+
+  renderContents(sectionIds, nodes) {
+    const sectionElement = this.super("renderContents", arguments);
+    const actionElements = sectionElement.querySelectorAll(
+      ":scope > .cbi-section-remove",
+    );
+
+    actionElements.forEach((actionElement, index) => {
+      const addMoveButton = (title, symbol, referenceId, after, disabled) => {
+        actionElement.insertBefore(
+          E(
+            "button",
+            {
+              class: "cbi-button cbi-button-neutral",
+              style: "border-color: currentColor",
+              title,
+              click: ui.createHandlerFn(
+                this,
+                "handleMove",
+                sectionIds[index],
+                referenceId,
+                after,
+              ),
+              disabled: this.map.readonly || disabled || null,
+            },
+            [symbol],
+          ),
+          actionElement.lastElementChild,
+        );
+      };
+
+      addMoveButton(
+        _("Move up"),
+        "↑",
+        sectionIds[index - 1],
+        false,
+        index === 0,
+      );
+      addMoveButton(
+        _("Move down"),
+        "↓",
+        sectionIds[index + 1],
+        true,
+        index === sectionIds.length - 1,
+      );
+    });
+
+    return sectionElement;
+  },
+});
+
 const EntryPoint = {
   async render() {
     main.injectGlobalStyles();
@@ -31,7 +91,7 @@ const EntryPoint = {
 
     // Sections tab
     const sectionsSection = podkopMap.section(
-      form.TypedSection,
+      SortableTypedSection,
       "section",
       _("Sections"),
     );


### PR DESCRIPTION
# Описание изменений

Добавлена возможность менять порядок секций Podkop на вкладке Sections в LuCI. Новый порядок сохраняется в UCI и используется при последовательной обработке секций.

## Что изменено

Детальное описание изменений:

- Рядом с кнопкой Delete добавлены нейтральные кнопки стрелок для перемещения секции.
- Перемещение выполняется через стандартный метод LuCI `uci.move()` с последующим сохранением формы.
- Для первой и последней секций недоступные направления перемещения автоматически отключаются.
- Существующий развёрнутый вид секций и формат конфигурации сохранены без изменений.

## Скриншот
<img width="206" height="49" alt="Screenshot from 2026-07-14 04-09-40" src="https://github.com/user-attachments/assets/f850b1a8-12de-4b7e-a6b3-c7c3f20833bd" />
